### PR TITLE
AbcExport patch from Daniel Rolinek on behalf of Tippett.

### DIFF
--- a/maya/AbcExport/MayaMeshWriter.cpp
+++ b/maya/AbcExport/MayaMeshWriter.cpp
@@ -158,13 +158,13 @@ getSetComponents( const MDagPath &dagPath, const MObject &SG, GetMembersMap& gmM
     if( status == MS::kFailure )
         return MS::kFailure;
 
-    // If the first plug in the array is connected, we have a whole object mapping. Return.
+    // if there are no elements,  this shading group is not connected as a face set
     if( iogPlug.numElements()<=0 )
         return MS::kFailure;
 
+    // the first element should always be connected as a source
     MPlugArray iogConnections;
     iogPlug.elementByLogicalIndex(0, &status).connectedTo(iogConnections, false, true, &status );
-    // this is not a shading group. skip it.
     if( status == MS::kFailure )
         return MS::kFailure;
 
@@ -203,7 +203,7 @@ getSetComponents( const MDagPath &dagPath, const MObject &SG, GetMembersMap& gmM
 
     // SG is a shading engine but has no components connected to the dagPath.
     // This means we have a whole object mapping!
-    return MS::kSuccess;
+    return MS::kFailure;
 }
 
 }
@@ -439,10 +439,7 @@ MayaMeshWriter::MayaMeshWriter(MDagPath & iDag,
 
         if (status != MS::kSuccess)
         {
-            MFnDependencyNode fnDepNode(connSGObj);
-            MString message;
-            message.format("Could not retrive face indices from set ^1s.",  connSgObjName);
-            MGlobal::displayError(message);
+            // for some reason the shading group doesn't represent a face set
             continue;
         }
 
@@ -825,7 +822,7 @@ void MayaMeshWriter::writeSubD(
         Alembic::Abc::Int32ArraySample(pointCounts));
     samp.setUVs( iUVs );
 
-    MPlug plug = lMesh.findPlug("facVaryingInterpolateBoundary");
+    MPlug plug = lMesh.findPlug("faceVaryingInterpolateBoundary");
     if (!plug.isNull())
         samp.setFaceVaryingInterpolateBoundary(plug.asInt());
 


### PR DESCRIPTION
1. only create face sets for shading groups applied with with per-face mappings
2. no longer produce an error for meshes without valid per-face mappings, e.g. whole object mappings
3. recognize "faceVaryingInterpolateBoundary",  not "faceVaryingInterpolateBoundary" as the control attribute for the related alembic property.
