### PR TITLE
adds asOgawa option to CreateArchiveWithInfo

### DIFF
--- a/python/PyAlembic/PyArchiveInfo.cpp
+++ b/python/PyAlembic/PyArchiveInfo.cpp
@@ -1,6 +1,6 @@
 //-*****************************************************************************
 //
-// Copyright (c) 2012,
+// Copyright (c) 2012-2014,
 //  Sony Pictures Imageworks Inc. and
 //  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
 //
@@ -44,15 +44,29 @@ static Abc::OArchive CreateArchiveWithInfoWrapper(
     const std::string &iApplicationWriter,
     const std::string &iUserDescription,
     const Abc::Argument &iArg0,
-    const Abc::Argument &iArg1 )
+    const Abc::Argument &iArg1,
+    bool asOgawa = false )
 {
-    return Abc::CreateArchiveWithInfo( 
-        ::Alembic::AbcCoreHDF5::WriteArchive(),
-        iFileName,
-        iApplicationWriter,
-        iUserDescription,
-        iArg0,
-        iArg1 );
+    if ( asOgawa == true )
+    {
+        return Abc::CreateArchiveWithInfo( 
+            ::Alembic::AbcCoreOgawa::WriteArchive(),
+            iFileName,
+            iApplicationWriter,
+            iUserDescription,
+            iArg0,
+            iArg1 );
+    }
+    else
+    {       
+        return Abc::CreateArchiveWithInfo( 
+            ::Alembic::AbcCoreHDF5::WriteArchive(),
+            iFileName,
+            iApplicationWriter,
+            iUserDescription,
+            iArg0,
+            iArg1 );
+    }
 }
 
 //-*****************************************************************************
@@ -86,7 +100,8 @@ void register_archiveinfo()
     def( "CreateArchiveWithInfo",
          CreateArchiveWithInfoWrapper,
          ( arg( "fileName" ), arg( "ApplicationWriter" ),
-           arg( "UserDescription" ), arg( "argument" ), arg( "argument" ) ),
+           arg( "UserDescription" ), arg( "argument" ) = Abc::Argument(), 
+           arg( "argument" ) = Abc::Argument(), arg( "asOgawa" ) = false ),
          "Create an OArchive with the passed arguments" );
     def( "GetArchiveInfo",
          GetArchiveInfoWrapper,

--- a/python/PyAlembic/PyArchiveInfo.cpp
+++ b/python/PyAlembic/PyArchiveInfo.cpp
@@ -45,7 +45,7 @@ static Abc::OArchive CreateArchiveWithInfoWrapper(
     const std::string &iUserDescription,
     const Abc::Argument &iArg0,
     const Abc::Argument &iArg1,
-    bool asOgawa = false )
+    bool asOgawa = true )
 {
     if ( asOgawa == true )
     {
@@ -101,7 +101,7 @@ void register_archiveinfo()
          CreateArchiveWithInfoWrapper,
          ( arg( "fileName" ), arg( "ApplicationWriter" ),
            arg( "UserDescription" ), arg( "argument" ) = Abc::Argument(), 
-           arg( "argument" ) = Abc::Argument(), arg( "asOgawa" ) = false ),
+           arg( "argument" ) = Abc::Argument(), arg( "asOgawa" ) = true ),
          "Create an OArchive with the passed arguments" );
     def( "GetArchiveInfo",
          GetArchiveInfoWrapper,

--- a/python/PyAlembic/PyOArchive.cpp
+++ b/python/PyAlembic/PyOArchive.cpp
@@ -1,6 +1,6 @@
 //-*****************************************************************************
 //
-// Copyright (c) 2012,
+// Copyright (c) 2012-2014,
 //  Sony Pictures Imageworks Inc. and
 //  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
 //
@@ -40,7 +40,7 @@ using namespace boost::python;
 
 //-*****************************************************************************
 static Abc::OArchive* mkOArchive( const std::string &iName, 
-                                  bool asOgawa = false )
+                                  bool asOgawa = true )
 {
     if ( asOgawa == true ) {
         return new Abc::OArchive( AbcO::WriteArchive(), iName );
@@ -61,7 +61,7 @@ void register_oarchive()
               make_constructor(
                   mkOArchive,
                   default_call_policies(),
-                  ( arg( "fileName" ), arg( "asOgawa" ) = false ) ),
+                  ( arg( "fileName" ), arg( "asOgawa" ) = true ) ),
               "Create an OArchive with the given file name" )
         .def( "getName",
               &Abc::OArchive::getName,


### PR DESCRIPTION
The HDF5 writer was hardcoded in CreateArchiveWithInfo previously. This adds an "asOgawa" option to the CreateArchiveWithInfo wrapper for the Alembic Python bindings, as well as default values for arg0 and arg1.