### PR TITLE
Feature : Add Ogawa support to Arnold Procedural.

### DIFF
--- a/arnold/Procedural/CMakeLists.txt
+++ b/arnold/Procedural/CMakeLists.txt
@@ -58,7 +58,10 @@ SET( CORE_LIBS
   AlembicAbcGeom
   AlembicAbc
   AlembicAbcCoreHDF5
+  AlembicAbcCoreOgawa
   AlembicAbcCoreAbstract
+  AlembicAbcCoreFactory
+  AlembicOgawa
   AlembicUtil )
 
 ADD_ARNOLD_CXX_PLUGIN( AlembicArnoldProcedural ProcMain.cpp ${H_FILES} ${CXX_FILES} )

--- a/arnold/Procedural/ProcMain.cpp
+++ b/arnold/Procedural/ProcMain.cpp
@@ -42,8 +42,7 @@
 #include "WriteGeo.h"
 
 #include <Alembic/AbcGeom/All.h>
-#include <Alembic/AbcCoreHDF5/All.h>
-
+#include <Alembic/AbcCoreFactory/All.h>
 
 namespace
 {
@@ -272,8 +271,9 @@ int ProcInit( struct AtNode *node, void **user_ptr )
         return 1;
     }
 
-    IArchive archive( ::Alembic::AbcCoreHDF5::ReadArchive(),
-                      args->filename );
+    Alembic::AbcCoreFactory::IFactory factory;
+    factory.setPolicy(ErrorHandler::kQuietNoopPolicy);
+    IArchive archive = factory.getArchive( args->filename );
 
     IObject root = archive.getTop();
 


### PR DESCRIPTION
Arnold produceral can only read HDF5 archive.
- Modify ProcMain.cpp to use factory
- Modify CMakeLists.txt to link with Ogawa library.

This is my first use of GitHub, i hope i made things correctly.
Marc