### PR TITLE
Minor build update

### DIFF
--- a/lib/AbcOpenGL/CMakeLists.txt
+++ b/lib/AbcOpenGL/CMakeLists.txt
@@ -34,7 +34,8 @@
 ##
 ##-*****************************************************************************
 
-INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/lib)
+INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/lib ${PROJECT_BINARY_DIR}/lib)
+
 
 SET(H_FILES
     DrawContext.h

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -33,9 +33,6 @@
 ##
 ##-*****************************************************************************
 
-# Include the source dirs to make the library root dir an include
-INCLUDE_DIRECTORIES(${ALEMBIC_LIBS_SOURCE_DIR} ${PROJECT_BINARY_DIR}/lib)
-
 ADD_SUBDIRECTORY(Alembic)
 
 # Include the AbcOpenGL lib

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,7 +34,7 @@
 ##-*****************************************************************************
 
 # Include the source dirs to make the library root dir an include
-INCLUDE_DIRECTORIES(${ALEMBIC_LIBS_SOURCE_DIR})
+INCLUDE_DIRECTORIES(${ALEMBIC_LIBS_SOURCE_DIR} ${PROJECT_BINARY_DIR}/lib)
 
 ADD_SUBDIRECTORY(Alembic)
 

--- a/python/PyAlembic/Foundation.h
+++ b/python/PyAlembic/Foundation.h
@@ -50,7 +50,7 @@
 // if Alembic uses shared_ptr from boost, then we don't need this function because boost provides it
 // if Alembic uses shared_ptr from std, then we don't need this function because boost provides it since 1.53
 // if Alembic uses shared_ptr from tr1, then we do need this function
-#if defined(ALEMBIC_LIB_USES_TR1)
+#if defined(ALEMBIC_LIB_USES_TR1) || BOOST_VERSION < 105300
 namespace boost
 {
 

--- a/python/PyAlembic/Foundation.h
+++ b/python/PyAlembic/Foundation.h
@@ -50,7 +50,7 @@
 // if Alembic uses shared_ptr from boost, then we don't need this function because boost provides it
 // if Alembic uses shared_ptr from std, then we don't need this function because boost provides it since 1.53
 // if Alembic uses shared_ptr from tr1, then we do need this function
-#if defined(ALEMBIC_LIB_USES_TR1) || BOOST_VERSION < 105300
+#if defined(ALEMBIC_LIB_USES_TR1) || (BOOST_VERSION < 105300 && !ALEMBIC_LIB_USES_BOOST)
 namespace boost
 {
 

--- a/python/PyAlembic/Foundation.h
+++ b/python/PyAlembic/Foundation.h
@@ -50,7 +50,7 @@
 // if Alembic uses shared_ptr from boost, then we don't need this function because boost provides it
 // if Alembic uses shared_ptr from std, then we don't need this function because boost provides it since 1.53
 // if Alembic uses shared_ptr from tr1, then we do need this function
-#if defined(ALEMBIC_LIB_USES_TR1) || (BOOST_VERSION < 105300 && !ALEMBIC_LIB_USES_BOOST)
+#if defined(ALEMBIC_LIB_USES_TR1) || (BOOST_VERSION < 105300 && !defined(ALEMBIC_LIB_USES_BOOST))
 namespace boost
 {
 


### PR DESCRIPTION
Fixes an out-of-source AbcOpenGL build error for missing Config.h file, and get_pointer redefinition error using older versions of gcc and boost (< 1.53).

See comments on https://github.com/alembic/alembic/commit/2f260c47a4dbf3419b759cfa3fbf5cfb1ad3a87f for more info. 