### PR TITLE
Fixes the static lib compilation on windows.

### DIFF
--- a/lib/Alembic/Ogawa/OStream.cpp
+++ b/lib/Alembic/Ogawa/OStream.cpp
@@ -52,6 +52,9 @@ public:
         if (filestream->is_open())
         {
             stream = filestream;
+#if defined _WIN32 || define _WIN64
+			filestream->rdbuf()->pubsetbuf(buffer, sizeof(buffer)); 
+#endif
             stream->exceptions ( std::ofstream::failbit |
                                  std::ofstream::badbit );
         }
@@ -91,6 +94,9 @@ public:
         }
     }
 
+#if defined _WIN32 || define _WIN64
+	char buffer [STREAM_BUF_SIZE];
+#endif
     std::ostream * stream;
     std::string fileName;
     Alembic::Util::uint64_t startPos;

--- a/lib/Alembic/Ogawa/OStream.cpp
+++ b/lib/Alembic/Ogawa/OStream.cpp
@@ -52,7 +52,7 @@ public:
         if (filestream->is_open())
         {
             stream = filestream;
-#if defined _WIN32 || define _WIN64
+#if defined _WIN32 || defined _WIN64
 			filestream->rdbuf()->pubsetbuf(buffer, sizeof(buffer)); 
 #endif
             stream->exceptions ( std::ofstream::failbit |
@@ -94,7 +94,7 @@ public:
         }
     }
 
-#if defined _WIN32 || define _WIN64
+#if defined _WIN32 || defined _WIN64
 	char buffer [STREAM_BUF_SIZE];
 #endif
     std::ostream * stream;

--- a/lib/Alembic/Ogawa/OStream.h
+++ b/lib/Alembic/Ogawa/OStream.h
@@ -41,6 +41,10 @@
 
 #include <ostream>
 
+#if defined _WIN32 || define _WIN64
+	#define STREAM_BUF_SIZE 1024*1024*2
+#endif
+
 namespace Alembic {
 namespace Ogawa {
 namespace ALEMBIC_VERSION_NS {

--- a/lib/Alembic/Ogawa/OStream.h
+++ b/lib/Alembic/Ogawa/OStream.h
@@ -41,7 +41,7 @@
 
 #include <ostream>
 
-#if defined _WIN32 || define _WIN64
+#if defined _WIN32 || defined _WIN64
 	#define STREAM_BUF_SIZE 1024*1024*2
 #endif
 

--- a/lib/Alembic/Util/Export.h
+++ b/lib/Alembic/Util/Export.h
@@ -45,8 +45,12 @@
     #endif
     #define ALEMBIC_EXPORT_CONST
 #else
-    #define ALEMBIC_EXPORT __attribute__ ((visibility ("default")))
-    #define ALEMBIC_EXPORT_CONST const
+	#if defined _WIN32 || defined _WIN64
+		#define ALEMBIC_EXPORT
+	#else
+		#define ALEMBIC_EXPORT __attribute__ ((visibility ("default")))
+	#endif
+	#define ALEMBIC_EXPORT_CONST const
 #endif
 
 #endif /* _Alembic_Util_Export_h_ */


### PR DESCRIPTION
Seems that vs2012/2013 doesn't like __attribute__ ((visibility ("default"))).
I'm not sure if it's important for linux/darwin, so I've put a condition for windows only.
It's the same syntax than openEXR (ie. https://github.com/openexr/openexr/blob/master/IlmBase/Half/halfExport.h)