### PR TITLE
AbcMaterial All.h header now gets installed

### DIFF
--- a/lib/Alembic/AbcMaterial/CMakeLists.txt
+++ b/lib/Alembic/AbcMaterial/CMakeLists.txt
@@ -43,6 +43,7 @@ LIST(APPEND CXX_FILES
 SET(CXX_FILES "${CXX_FILES}" PARENT_SCOPE)
 
 INSTALL(FILES
+    All.h
     SchemaInfoDeclarations.h
     OMaterial.h
     IMaterial.h


### PR DESCRIPTION
AbcMaterial's All.h header wasn't included in the list of header files to install. This pull requests adds it to the list of files to install.