### PR TITLE
Fix export/import when using multi-byte file names

### DIFF
--- a/maya/AbcExport/AbcExport.cpp
+++ b/maya/AbcExport/AbcExport.cpp
@@ -281,7 +281,7 @@ try
                     MGlobal::displayError("File incorrectly specified.");
                     return MS::kFailure;
                 }
-                fileName = jobArgsArray[++i].asUTF8();
+                fileName = jobArgsArray[++i].asChar();
             }
 
             else if (arg == "-fr" || arg == "-framerange")

--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -464,7 +464,7 @@ MStatus AlembicNode::compute(const MPlug & plug, MDataBlock & dataBlock)
         Alembic::Abc::IArchive archive;
         Alembic::AbcCoreFactory::IFactory factory;
         factory.setPolicy(Alembic::Abc::ErrorHandler::kQuietNoopPolicy);
-        archive = factory.getArchive(fileName.asUTF8());
+        archive = factory.getArchive(fileName.asChar());
 
         if (!archive.valid())
         {

--- a/maya/AbcImport/NodeIteratorVisitorHelper.cpp
+++ b/maya/AbcImport/NodeIteratorVisitorHelper.cpp
@@ -2863,7 +2863,7 @@ MString createScene(ArgData & iArgData)
     Alembic::Abc::IArchive archive;
     Alembic::AbcCoreFactory::IFactory factory;
     factory.setPolicy(Alembic::Abc::ErrorHandler::kQuietNoopPolicy);
-    archive = factory.getArchive(iArgData.mFileName.asUTF8());
+    archive = factory.getArchive(iArgData.mFileName.asChar());
     if (!archive.valid())
     {
         MString theError = iArgData.mFileName;


### PR DESCRIPTION
Maya is a MBCS application and it uses the native character encoding. By default, it's SHIFT-JIS (Japanese) and GBK (Chinese S.) on Windows. On Linux/Mac, the system default is usually UTF8. This commit changes from asUTF8() to asChar() so that the returned char* is in the native encoding. This fixes MBCS filenames on Windows.

CL 872750, 874437

On Linux/MacOS, the default codepage is UTF8 so asUTF8() happens to
work. But Maya is using the current codepage on Windows. This can be
shift-jis or gbk.  asChar() will return the multi-byte sequence in the
current codepage.  Both Ogawa and HDF5 accepts a std::string as their
parameter. They are not treating the file name parameter as UTF8 as
well. They pass the char* to fopen() or std::ifstream() and both are
using the current codepage.