### PR TITLE
Implements {get,set}ExternalContent for AlembicNode

### DIFF
--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -66,6 +66,9 @@
 #include <maya/MFnTypedAttribute.h>
 #include <maya/MFnUnitAttribute.h>
 #include <maya/MFnEnumAttribute.h>
+#if defined(MAYA_WANT_EXTERNALCONTENTTABLE)
+#include <maya/MExternalContentInfoTable.h>
+#endif
 
 #include <Alembic/AbcCoreFactory/IFactory.h>
 #include <Alembic/AbcCoreHDF5/ReadWrite.h>
@@ -1081,4 +1084,18 @@ MStringArray AlembicNode::getFilesToArchive(
 
     return files;
 }
+
+#if defined(MAYA_WANT_EXTERNALCONTENTTABLE)
+void AlembicNode::getExternalContent(MExternalContentInfoTable& table) const
+{
+   addExternalContentForFileAttr(table, mAbcFileNameAttr);
+   MPxNode::getExternalContent(table);
+}
+
+void AlembicNode::setExternalContent(const MExternalContentLocationTable& table)
+{
+   setExternalContentForFileAttr(mAbcFileNameAttr, table);
+   MPxNode::setExternalContent(table);
+}
+#endif
 

--- a/maya/AbcImport/AlembicNode.h
+++ b/maya/AbcImport/AlembicNode.h
@@ -123,6 +123,10 @@ public:
     virtual MStringArray getFilesToArchive(bool shortName,
                                            bool unresolvedName,
                                            bool markCouldBeImageSequence) const;
+#if defined(MAYA_WANT_EXTERNALCONTENTTABLE)                                           
+    virtual	void getExternalContent(MExternalContentInfoTable& table) const;
+	virtual	void setExternalContent(const MExternalContentLocationTable& table);
+#endif
 
     void   setDebugMode(bool iDebugOn){ mDebugOn = iDebugOn; }
     void   setIncludeFilterString(const MString & iIncludeFilterString)


### PR DESCRIPTION
The external content table is an extension to let Maya know that a depend node attribute references any external files. This commit add support for MFnDependencyNode::getExternalContent() in AlembicNode.

CL 863332

Implements {get,set}ExternalContent for a collection of Maya nodes that
are simple to handle.