### PR TITLE
Performance: Alembic tests are crashing in parallel

### DIFF
--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -1053,11 +1053,13 @@ bool AlembicNode::isPassiveOutput(const MPlug & plug) const
     return MPxNode::isPassiveOutput( plug );
 }
 
+#if MAYA_API_VERSION >= 201600
 AlembicNode::SchedulingType AlembicNode::schedulingType()const
 {
 	// Globally serialize this node because the compute method is not thread safe
     return kGloballySerialize;
 }
+#endif
 
 
 // returns the list of files to archive.

--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -1053,6 +1053,13 @@ bool AlembicNode::isPassiveOutput(const MPlug & plug) const
     return MPxNode::isPassiveOutput( plug );
 }
 
+AlembicNode::SchedulingType AlembicNode::schedulingType()const
+{
+	// Globally serialize this node because the compute method is not thread safe
+    return kGloballySerialize;
+}
+
+
 // returns the list of files to archive.
 MStringArray AlembicNode::getFilesToArchive(
     bool /* shortName */,

--- a/maya/AbcImport/AlembicNode.h
+++ b/maya/AbcImport/AlembicNode.h
@@ -114,6 +114,7 @@ public:
 
     // override virtual methods from MPxNode
     virtual bool isPassiveOutput(const MPlug & plug) const;
+    virtual SchedulingType schedulingType()const;
 
     // initialize all the attributes to default values
     static MStatus initialize();

--- a/maya/AbcImport/AlembicNode.h
+++ b/maya/AbcImport/AlembicNode.h
@@ -114,7 +114,9 @@ public:
 
     // override virtual methods from MPxNode
     virtual bool isPassiveOutput(const MPlug & plug) const;
+#if MAYA_API_VERSION >= 201600
     virtual SchedulingType schedulingType()const;
+#endif
 
     // initialize all the attributes to default values
     static MStatus initialize();


### PR DESCRIPTION
AlembicNode failed to run in parallel with EM=on. The scheduling type is set to kGloballySerialize so that behaves in the same way as before.

CL 936414

Alembic node is not not threadsafe schedulingType could not be set for
plugin nodes

o Updated the way Alembic gets globallySerialized(removed patch)