### PR TITLE
Print raw full name instead of resolved full name

### DIFF
--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -468,7 +468,9 @@ MStatus AlembicNode::compute(const MPlug & plug, MDataBlock & dataBlock)
 
         if (!archive.valid())
         {
-            MString theError = "Cannot read file " + fileName;
+            //The resolved full name will be empty if the resolution fails.
+            //Print the raw full name in case of this situation.
+            MString theError = "Cannot read file " + fileObject.rawFullName();
             printError(theError);
         }
 


### PR DESCRIPTION
The resolved file name may be empty if Maya fails to find the file. Just show the raw file name.

CL 815869

When loading Alembic file fails, print the raw full name instead of the
resolved full name, for the resolved full name is likely to be empty if
the corresponding file doesn't exist.