### PR TITLE
Add an error message when someone tries to repath an Alembic node

### DIFF
--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -431,6 +431,26 @@ double AlembicNode::computeRetime(const double inputTime,
     return retime;
 }
 
+MStatus AlembicNode::setDependentsDirty(const MPlug& plug, MPlugArray& plugArray)
+{
+	if (plug == mAbcFileNameAttr)
+	{
+/* 	This code was to force refresh of the AlembicNode when there is a file name change
+	But since it was only working in particular very simple case, we decided to not enable it
+	and only display a warning.
+	In all other cases it could result in undesired behavior even scene corruption.
+	See issue MAYA-47471
+		mFileInitialized = false;
+        mCurTime = DBL_MAX;	// to force update
+*/
+		if(mFileInitialized)
+		{
+			MGlobal::displayWarning("Repathing Alembic Nodes is not supported");
+		}
+	}
+	return MPxNode::setDependentsDirty(plug, plugArray);
+}
+
 MStatus AlembicNode::compute(const MPlug & plug, MDataBlock & dataBlock)
 {
     MStatus status;

--- a/maya/AbcImport/AlembicNode.h
+++ b/maya/AbcImport/AlembicNode.h
@@ -113,6 +113,7 @@ public:
     static void* creator() { return (new AlembicNode()); }
 
     // override virtual methods from MPxNode
+	virtual MStatus setDependentsDirty(const MPlug& plug, MPlugArray& plugArray);
     virtual bool isPassiveOutput(const MPlug & plug) const;
 
     // initialize all the attributes to default values


### PR DESCRIPTION
It may cause problems if the user changes the file in AlembicNode when the file contains a different hierarchy. We print a message to warn the risk.

CL 939772, 942967

Add an error message when someone tries to repath an Alembic node
"//Warning: Repathing Alembic Nodes is not supported//