### PR TITLE
Add face sets after connections are made

### DIFF
--- a/maya/AbcImport/CreateSceneHelper.cpp
+++ b/maya/AbcImport/CreateSceneHelper.cpp
@@ -409,6 +409,22 @@ void CreateSceneVisitor::applyShaderSelection()
     mShaderMeshMap.clear();
 }
 
+// add face sets after connections are made
+void CreateSceneVisitor::addFaceSetsAfterConnection()
+{
+    std::map < MObject, Alembic::Abc::IObject, ltMObj >::iterator i =
+        mAddFaceSetsMap.begin();
+
+    std::map < MObject, Alembic::Abc::IObject, ltMObj >::iterator end =
+        mAddFaceSetsMap.end();
+
+    for (; i != end; ++i)
+    {
+        MObject dagNode = i->first;
+        addFaceSets(dagNode, i->second);
+    }
+}
+
 void CreateSceneVisitor::addToPropList(std::size_t iFirst, MObject & iObject)
 {
     std::size_t last = mData.mPropList.size();
@@ -1079,6 +1095,7 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::ISubD& iNode)
         if (!isConstant || colorAnim)
         {
             mData.mSubDObjList.push_back(subDObj);
+            mAddFaceSetsMap[subDObj] = iNode;
         }
     }
 
@@ -1178,6 +1195,7 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::IPolyMesh& iNode)
         if (!isConstant || colorAnim)
         {
             mData.mPolyMeshObjList.push_back(polyObj);
+            mAddFaceSetsMap[polyObj] = iNode;
         }
     }
 

--- a/maya/AbcImport/CreateSceneHelper.h
+++ b/maya/AbcImport/CreateSceneHelper.h
@@ -133,6 +133,9 @@ public:
     // re-add the shader selection back to the sets for meshes
     void applyShaderSelection();
 
+    // add face sets after the connections are made
+    void addFaceSetsAfterConnection();
+
 private:
 
     // helper function for building mShaderMeshMap
@@ -176,6 +179,10 @@ private:
     // of parts of meshes.  They are to get around a problem where a shape
     // wont shade correctly after a swap if it is shaded per face
     std::map < MObject, MSelectionList, ltMObj > mShaderMeshMap;
+
+    // adding face sets after the connections are made. The order is
+    // important to deal with construction history.
+    std::map < MObject, Alembic::Abc::IObject, ltMObj > mAddFaceSetsMap;
 };  // class CreateSceneVisitor
 
 

--- a/maya/AbcImport/NodeIteratorVisitorHelper.cpp
+++ b/maya/AbcImport/NodeIteratorVisitorHelper.cpp
@@ -2905,6 +2905,8 @@ MString createScene(ArgData & iArgData)
         visitor.applyShaderSelection();
     }
 
+    visitor.addFaceSetsAfterConnection();
+
     return returnName;
 }
 


### PR DESCRIPTION
This commit fixed an issue that the per-face material assignment is lost when there is construction history. addFaceSets() should happen after connecting inMesh.

CL 917596

Maya deals with per-face shading group assignment differently, depending
on whether there is construction history.
If there is construction history (defomer in this case), Maya should
insert groupId nodes instead of changing the mesh geom.
The bug is caused by assigning per-face shading group before connection
AlembicNode to poly.inMesh plug. The group ids are lost when a new poly
flows from the constructon history (AlembicNode).