### PR TITLE
Fix that Alembic doesn't work with dir mapping correctly

### DIFF
--- a/maya/AbcImport/AbcImport.cpp
+++ b/maya/AbcImport/AbcImport.cpp
@@ -280,6 +280,7 @@ MStatus AbcImport::doIt(const MArgList & args)
             // resolve the relative path
             MFileObject absoluteFile;
             absoluteFile.setRawFullName(filename);
+			absoluteFile.setResolveMethod(MFileObject::kInputFile);
 #if MAYA_API_VERSION < 201300
             if (absoluteFile.resolvedFullName() !=
                 absoluteFile.expandedFullName())


### PR DESCRIPTION
Set the resolve method to kInputFile so that Maya can resolve the file name by the current workspace settings.

CL 957174

When doing import, Alembic won't resolve the file path with dir mapping.
Add this step by telling the file path resolver.