### PR TITLE
Feed referenced meshes with an intermediate mesh instead of setting d…

### DIFF
--- a/maya/AbcImport/CreateSceneHelper.cpp
+++ b/maya/AbcImport/CreateSceneHelper.cpp
@@ -309,6 +309,52 @@ namespace
 
         return false;
     }
+
+    void connectIntermediateMesh(MFnMesh& ioFn, MFnMesh& fn)
+    {
+        // Maya doesn't allow to delete history on a referenced mesh. We
+        // can't disconnect the history and change it via MFnMesh directly.
+        // Instead, we could create an intermediate mesh and connect it to
+        // the inMesh plug of the referenced mesh.
+        // To avoid leaving orphan intermediate mesh in the scene, we
+        // tag the intermediate mesh with a dynamic attribute so that
+        // it can be deleted properly when imported again.
+        MDGModifier modifier;
+
+        // Create the dynamic attribute to indicate that the mesh is an
+        // intermediate mesh.
+        MFnNumericAttribute numericAttr;
+        MObject aioAttr = numericAttr.create(
+            "AlembicIntermediateObject", "aio", MFnNumericData::kBoolean);
+        modifier.addAttribute(ioFn.object(), aioAttr);
+        modifier.doIt();
+
+        // Set the intermediate mesh as Maya intermediate object and
+        // connect it to the inMesh plug
+        modifier.renameNode(ioFn.object(), fn.name() + "Orig");
+        modifier.newPlugValueBool(ioFn.findPlug("intermediateObject"), true);
+        modifier.newPlugValueBool(ioFn.findPlug(aioAttr), true);
+        modifier.connect(ioFn.findPlug("outMesh"), fn.findPlug("inMesh"));
+        modifier.doIt();
+    }
+
+    void deleteIntermediateMesh(MFnMesh& fn)
+    {
+        // When merge with a referenced node with history, delete the
+        // previous intermediate mesh that is created by Alembic plug-in.
+        MPlugArray sources;
+        fn.findPlug("inMesh").connectedTo(sources, true, false);
+        if (sources.length() > 0)
+        {
+            MObject io = sources[0].node();
+            if (MFnMesh(io).hasAttribute("AlembicIntermediateObject"))
+            {
+                MDGModifier modifier;
+                modifier.deleteNode(io);
+                modifier.doIt();
+            }
+        }
+    }
 }
 
 
@@ -1107,15 +1153,30 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::ISubD& iNode)
             return MS::kFailure;
         }
 
+        // the mesh from Alembic is static but the Maya mesh is referenced.
+        // direct changes to the Maya mesh will lost after unloading/loading
+        // the reference file. we create an intermediate mesh and connect
+        // it to the Maya mesh.
+        MFnMesh ioFn;
+        if (isConstant && fn.isFromReferencedFile())
+        {
+            deleteIntermediateMesh(fn);
+            ioFn.setObject(createSubD(mFrame, subdAndFriends, mParent));
+        }
+
         if (mConnectDagNode.isValid())
         {
             checkShaderSelection(fn, mConnectDagNode.instanceNumber());
         }
 
         disconnectMesh(subDObj, mData.mPropList, firstProp);
+        fn.setObject(subDObj);
         if (isConstant && CONNECT == mAction)
         {
-            readSubD(mFrame, fn, subDObj, subdAndFriends, false);
+            if (ioFn.object().hasFn(MFn::kMesh))
+                connectIntermediateMesh(ioFn, fn);
+            else
+                readSubD(mFrame, fn, subDObj, subdAndFriends, false);
         }
         addToPropList(firstProp, subDObj);
     }
@@ -1206,13 +1267,28 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::IPolyMesh& iNode)
             return status;
         }
 
+        // the mesh from Alembic is static but the Maya mesh is referenced.
+        // direct changes to the Maya mesh will lost after unloading/loading
+        // the reference file. we create an intermediate mesh and connect
+        // it to the Maya mesh.
+        MFnMesh ioFn;
+        if (isConstant && fn.isFromReferencedFile())
+        {
+            deleteIntermediateMesh(fn);
+            ioFn.setObject(createPoly(mFrame, meshAndFriends, mParent));
+        }
+
         if (mConnectDagNode.isValid())
             checkShaderSelection(fn, mConnectDagNode.instanceNumber());
 
         disconnectMesh(polyObj, mData.mPropList, firstProp);
+        fn.setObject(polyObj);
         if (isConstant && CONNECT == mAction)
         {
-            readPoly(mFrame, fn, polyObj, meshAndFriends, false);
+            if (ioFn.object().hasFn(MFn::kMesh))
+                connectIntermediateMesh(ioFn, fn);
+            else
+                readPoly(mFrame, fn, polyObj, meshAndFriends, false);
         }
         addToPropList(firstProp, polyObj);
     }


### PR DESCRIPTION
This commit fixed an issue when doing AbcImport to a referenced mesh. A referenced mesh is readonly so we can't change it using MFnMesh. Instead, we create an intermediate mesh and connect it to the referenced mesh's inMesh.

CL 970895, 971367

In Merge mode, Alembic will disconnect the inMesh plug and set the data
via MFnMesh interface directly. This works fine if the mesh is
read/writeable. This approach doesn't work properly when the Maya mesh
is from referenced from a file. Maya doesn't not support deleting
history on a mesh which is referenced..

The solution is to create an intermediate mesh and set data to the
intermediate mesh. Then disconnect the inMesh of the referenced mesh and
connect the intermediate mesh instead. This should generate two
reference edits: disconnectAttr and connectAttr.

Note that Alembic has the mesh data and merge mode should update the
mesh with the data from the Alembic file. So we can't retain the
connection. We need to feed the mesh with the Alembic mesh.