### PR TITLE
Fix exporting the animation of spline ik

### DIFF
--- a/maya/AbcExport/MayaTransformWriter.cpp
+++ b/maya/AbcExport/MayaTransformWriter.cpp
@@ -956,16 +956,8 @@ void MayaTransformWriter::pushTransformStack(const MFnTransform & iTrans,
 void MayaTransformWriter::pushTransformStack(const MFnIkJoint & iJoint,
     bool iForceStatic)
 {
-    // check joints that are driven by Maya FBIK
-    // Maya FBIK has no connection to joints' TRS plugs
-    // but TRS of joints are driven by FBIK, they are not static
-    // Maya 2012's new HumanIK has connections to joints.
-    // FBIK is a special case.
-    bool forceAnimated = false;
-    MStatus status = MS::kSuccess;
-    if (iJoint.hikJointName(&status).length() > 0 && status) {
-        forceAnimated = true;
-    }
+    // Some special cases that the joint is animated but has no input connections.
+    bool forceAnimated = util::isDrivenByFBIK(iJoint) || util::isDrivenBySplineIK(iJoint);
 
     // inspect the translate
     addTranslate(iJoint, "translate", "translateX", "translateY", "translateZ",

--- a/maya/AbcExport/MayaUtility.cpp
+++ b/maya/AbcExport/MayaUtility.cpp
@@ -335,6 +335,49 @@ bool util::isAnimated(MObject & object, bool checkParent)
     return false;
 }
 
+bool util::isDrivenByFBIK(const MFnIkJoint & iJoint)
+{
+    // check joints that are driven by Maya FBIK
+    // Maya FBIK has no connection to joints' TRS plugs
+    // but TRS of joints are driven by FBIK, they are not static
+    // Maya 2012's new HumanIK has connections to joints.
+    // FBIK is a special case.
+    MStatus status = MS::kSuccess;
+    if (iJoint.hikJointName(&status).length() > 0 && status) {
+        return true;
+    }
+    return false;
+}
+
+bool util::isDrivenBySplineIK(const MFnIkJoint & iJoint)
+{
+    // spline IK can drive the starting joint's translate channel but
+    // it has no connection to the translate plug.
+    // we treat the joint as animated in this case.
+    // find the ikHandle node.
+    MPlug msgPlug = iJoint.findPlug("message", false);
+    MPlugArray msgPlugDst;
+    msgPlug.connectedTo(msgPlugDst, false, true);
+    for (unsigned int i = 0; i < msgPlugDst.length(); i++) {
+        MFnDependencyNode ikHandle(msgPlugDst[i].node());
+        if (!ikHandle.object().hasFn(MFn::kIkHandle)) continue;
+
+        // find the ikSolver node.
+        MPlug ikSolverPlug = ikHandle.findPlug("ikSolver");
+        MPlugArray ikSolverDst;
+        ikSolverPlug.connectedTo(ikSolverDst, true, false);
+        for (unsigned int j = 0; j < ikSolverDst.length(); j++) {
+
+            // return true if the ikSolver is a spline solver.
+            if (ikSolverDst[j].node().hasFn(MFn::kSplineSolver)) {
+                return true;
+            }
+        }
+    }
+    
+    return false;
+}
+
 bool util::isIntermediate(const MObject & object)
 {
     MStatus stat;

--- a/maya/AbcExport/MayaUtility.h
+++ b/maya/AbcExport/MayaUtility.h
@@ -115,6 +115,14 @@ bool getRotOrder(MTransformationMatrix::RotationOrder iOrder,
 // copy from mayapit code (MayaPit.h .cpp)
 bool isAnimated(MObject & object, bool checkParent = false);
 
+// determine if a joint is driven by FBIK.
+// The joint is animated but has no input connections.
+bool isDrivenByFBIK(const MFnIkJoint & iJoint);
+
+// determine if a joint is driven by a spline ik.
+// The joint's is animated but has no input connections.
+bool isDrivenBySplineIK(const MFnIkJoint & iJoint);
+
 // determine if a Maya Object is intermediate
 bool isIntermediate(const MObject & object);
 


### PR DESCRIPTION
Spline IK has no explicit connections to the translate channel but it does drives the translation. we need to check the situation and set forceAnimated to true.

CL 904969

The spline ik has no connections to the translate channel of the
starting joint.
But it will affect the translate channel.
We check if the joint is the starting joint of the spline ik. If so, we
treat it as animated even if it has no input connections.