### PR TITLE
EM race condition when evaluating fan-out connections in parallel

### DIFF
--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -723,7 +723,18 @@ MStatus AlembicNode::compute(const MPlug & plug, MDataBlock & dataBlock)
     {
         if (mOutRead[2])
         {
-            dataBlock.setClean(plug);
+            // Reference the output to let EM know we are the writer
+            // of the data. EM sets the output to holder and causes
+            // race condition when evaluating fan-out destinations.
+            MArrayDataHandle outArrayHandle =
+                dataBlock.outputValue(mOutSubDArrayAttr, &status);
+            const unsigned int elementCount = outArrayHandle.elementCount();
+            for (unsigned int j = 0; j < elementCount; j++)
+            {
+                outArrayHandle.outputValue().data();
+                outArrayHandle.next();
+            }
+            outArrayHandle.setAllClean();
             return MS::kSuccess;
         }
 
@@ -798,7 +809,18 @@ MStatus AlembicNode::compute(const MPlug & plug, MDataBlock & dataBlock)
     {
         if (mOutRead[3])
         {
-            dataBlock.setClean(plug);
+            // Reference the output to let EM know we are the writer
+            // of the data. EM sets the output to holder and causes
+            // race condition when evaluating fan-out destinations.
+            MArrayDataHandle outArrayHandle =
+                dataBlock.outputValue(mOutPolyArrayAttr, &status);
+            const unsigned int elementCount = outArrayHandle.elementCount();
+            for (unsigned int j = 0; j < elementCount; j++)
+            {
+                outArrayHandle.outputValue().data();
+                outArrayHandle.next();
+            }
+            outArrayHandle.setAllClean();
             return MS::kSuccess;
         }
 
@@ -946,7 +968,18 @@ MStatus AlembicNode::compute(const MPlug & plug, MDataBlock & dataBlock)
     {
         if (mOutRead[5])
         {
-            dataBlock.setClean(plug);
+            // Reference the output to let EM know we are the writer
+            // of the data. EM sets the output to holder and causes
+            // race condition when evaluating fan-out destinations.
+            MArrayDataHandle outArrayHandle =
+                dataBlock.outputValue(mOutNurbsSurfaceArrayAttr, &status);
+            const unsigned int elementCount = outArrayHandle.elementCount();
+            for (unsigned int j = 0; j < elementCount; j++)
+            {
+                outArrayHandle.outputValue().data();
+                outArrayHandle.next();
+            }
+            outArrayHandle.setAllClean();
             return MS::kSuccess;
         }
 
@@ -985,7 +1018,18 @@ MStatus AlembicNode::compute(const MPlug & plug, MDataBlock & dataBlock)
     {
         if (mOutRead[6])
         {
-            dataBlock.setClean(plug);
+            // Reference the output to let EM know we are the writer
+            // of the data. EM sets the output to holder and causes
+            // race condition when evaluating fan-out destinations.
+            MArrayDataHandle outArrayHandle =
+                dataBlock.outputValue(mOutNurbsCurveGrpArrayAttr, &status);
+            const unsigned int elementCount = outArrayHandle.elementCount();
+            for (unsigned int j = 0; j < elementCount; j++)
+            {
+                outArrayHandle.outputValue().data();
+                outArrayHandle.next();
+            }
+            outArrayHandle.setAllClean();
             return MS::kSuccess;
         }
 


### PR DESCRIPTION
With the latest Evaluation Manager, we identified an issue that a plug-in must use outputValue() to reference its output in compute(), even if there are no changes to the output. Just setting datablock to clean is not enough. The issue happens when the user connects the AlembicNode.outPolyMesh[x] to more than one meshShape.

CL 994822

EM calls TevaluationGraph::makeDataSharable() method to make all Tdata
to be holders before evaluation. This makes the output
(AbcImport.outPolyMesh[0] plug) to be a holder. AbcImport just sets the
datablock clean in its compute() because there are no changes to the
mesh data. So the output remains to be a holder. Then EM evaluates the
fan-out destination mesh shapes in parallel. In TmeshShape's
computeObject(), they evaluate the inMesh connection and call
AbcImport.outPolyMesh[0] Tdata's makeWritable in parallel.. This breaks
reference counting and caused the mesh data to be deleted unexpectedly..