### PR TITLE
1.6 msvc build is broken. 

### DIFF
--- a/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
+++ b/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
@@ -47,7 +47,18 @@ namespace ALEMBIC_VERSION_NS {
 #define COMPARE_EXCHANGE( V, COMP, EXCH ) V.compare_exchange_weak( COMP, EXCH, std::memory_order_seq_cst, std::memory_order_seq_cst )
 // Windows
 #elif defined( _MSC_VER )
-#define COMPARE_EXCHANGE( V, COMP, EXCH ) InterlockedCompareExhange64( &V, EXCH, COMP ) == COMP
+#define COMPARE_EXCHANGE( V, COMP, EXCH ) InterlockedCompareExchange64( &V, EXCH, COMP ) == COMP
+int ffsll(long	long value)
+{
+	if (!value)
+		return 0;
+
+	for (int bit = 0; bit < 63; bit++)
+	{
+		if (value & (1 << bit))
+			return bit + 1;
+	}
+}
 // gcc 4.8 and above not using C++11
 #elif defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 8
 #define COMPARE_EXCHANGE( V, COMP, EXCH ) __atomic_compare_exchange_n( &V, &COMP, EXCH, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST )


### PR DESCRIPTION
the 1.6 branch is currently broken on windows with msvc due to a typo in InterlockedCompareExhange64 and missing ffsll function (glibc extention function) , this patch addresses both. 