### PR TITLE
Fix transforming groups of NURBS curves

### DIFF
--- a/maya/AbcExport/MayaNurbsCurveWriter.cpp
+++ b/maya/AbcExport/MayaNurbsCurveWriter.cpp
@@ -74,11 +74,22 @@ namespace
                         continue;
                     }
 
-                    // with the flag set to true, check the DagPath and it's
-                    // parent
-                    if (util::isAnimated(curve, true))
+                    // with the flag set to true, check the DagPath and its
+                    // parent.  
+                    // Note since we're collecting a group of curves, and
+                    // if  even one is animated, the whole group will be,
+                    // so don't bother checking additional curves.
+                    if (!oIsAnimated)
                     {
-                        oIsAnimated = true;
+                        if (util::isAnimated(curve, true))
+                        {
+                            oIsAnimated = true;
+                        }
+                        MObject curveXform(curvePath.transform());
+                        if (util::isAnimated(curveXform), true)
+                        {
+                            oIsAnimated = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Bugfix for writing groups of NURBS curves whose only animation are
transformations.  Also, don't bother checking the animation status of every
curve in a group if one has already been found to be animated, as the check can
be expensive.