### PR TITLE
disables linking to -mt variants on osx, removes unnecessary boost th…

### DIFF
--- a/cmake/AlembicBoost.cmake
+++ b/cmake/AlembicBoost.cmake
@@ -1,6 +1,6 @@
 ##-*****************************************************************************
 ##
-## Copyright (c) 2009-2015,
+## Copyright (c) 2009-2016,
 ##  Sony Pictures Imageworks Inc. and
 ##  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
 ##
@@ -71,13 +71,17 @@ ENDIF()
 #-******************************************************************************
 
 SET(Boost_USE_STATIC_LIBS ${USE_STATIC_BOOST})
-SET(Boost_USE_MULTITHREADED ON)
 SET(Boost_NO_BOOST_CMAKE ON) 
 
+# disables linking to -mt variants on osx
+IF (USE_PYALEMBIC AND APPLE)
+    SET(Boost_USE_MULTITHREADED OFF)
+ENDIF()
+
 IF (USE_PYALEMBIC)
-    FIND_PACKAGE(Boost 1.42.0 COMPONENTS program_options python REQUIRED thread)
+    FIND_PACKAGE(Boost 1.42.0 COMPONENTS program_options python)
 ELSE()
-    FIND_PACKAGE(Boost 1.42.0 COMPONENTS program_options REQUIRED thread)
+    FIND_PACKAGE(Boost 1.42.0 COMPONENTS program_options)
 ENDIF()
 
 #-******************************************************************************


### PR DESCRIPTION
Fixes an import issue on osx, and removes boost/thread requirement since it's not used and also not installed by default on osx when using `brew install boost`. 

The alembic import issue on osx:
```
>>> import alembic
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: No Python class registered for C++ class PyImath::FixedArrayBool<bool>
```

This is caused by linking to libboost_python-mt.so when PyImath is linked to libboost_python.so. This creates two type registries and the above import issue. However, the boost -mt variant suffix has been deprecated for a while:

https://svn.boost.org/trac/boost/ticket/4936

    The -mt suffix has been removed. If you still want it use ./bjam --layout=tagged install.

Users who use homebrew to install boost on osx will get the -mt variants because the brew recipe uses the --layout=tagged option,

https://github.com/Homebrew/homebrew-core/blob/master/Formula/boost.rb#L110

but linking to this causes the above import issue. Setting Boost_USE_MULTITHREADING to OFF on osx tells cmake to link to the regular libboost_python.so library (which is still multithreaded). On linux it should only make a different if you also build boost with --layout=tagged. If that seems likely, then we can just set it to OFF for all platforms.