### PR TITLE
Fix CoreOgawa::StreamManager CAS impl on MSVC

### DIFF
--- a/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
+++ b/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
@@ -47,7 +47,7 @@ namespace ALEMBIC_VERSION_NS {
 #define COMPARE_EXCHANGE( V, COMP, EXCH ) V.compare_exchange_weak( COMP, EXCH, std::memory_order_seq_cst, std::memory_order_seq_cst )
 // Windows
 #elif defined( _MSC_VER )
-#define COMPARE_EXCHANGE( V, COMP, EXCH ) InterlockedCompareExchange64( &V, EXCH, COMP ) == COMP
+#define COMPARE_EXCHANGE( V, COMP, EXCH ) (InterlockedCompareExchange64( &V, EXCH, COMP ) == COMP)
 
 Alembic::Util::int64_t ffsll( Alembic::Util::int64_t iValue )
 {


### PR DESCRIPTION
Precedence of '!' > precedence of '==' -> parenthesis needed.

In current implementation, condition "! COMPARE_EXCHANGE( m_streams, oldVal, newVal )" never succeeds.
Consequences are:
- several threads end up reading the same file stream
- some streams are Missed In Action -> m_default is being used instead