### PR TITLE
Ability to connect the AlembicNode to first shape of the current parent

### DIFF
--- a/maya/AbcImport/AbcImport.cpp
+++ b/maya/AbcImport/AbcImport.cpp
@@ -97,6 +97,13 @@ scene but doesn't exist in the archive, children of that node will be connected\
 -eft / excludeFilterObjects \"regex1 regex2 ...\"                          \n\
                     Selective exclude cache objects whose name matches with \n\
 the input regular expressions.                                              \n\
+-fas / useFirstAvailableShape                                               \n\
+                    Determines if it's necessary to use the first available \n\
+                    DAG node of the current parent node when it's not       \n\
+                    possible to find the DAG node to connect it to the      \n\
+                    AlembicNode. It can be useful when the Alembic file was \n\
+                    exported after Maya renamed the shapes nodes of an      \n\
+                    object (it happens when deforming reference objects).   \n\
 -h  / help          Print this message                                      \n\
 -d  / debug         Turn on debug message printout                        \n\n\
 Example:                                                                    \n\
@@ -126,6 +133,7 @@ MSyntax AbcImport::createSyntax()
     syntax.addFlag("-h",    "-help",         MSyntax::kNoArg);
     syntax.addFlag("-m",    "-mode",         MSyntax::kString);
     syntax.addFlag("-rcs",  "-recreateAllColorSets", MSyntax::kNoArg);
+    syntax.addFlag("-fas",  "-useFirstAvailableShape",  MSyntax::kNoArg);
 
     syntax.addFlag("-ct",   "-connect",          MSyntax::kString);
     syntax.addFlag("-crt",  "-createIfNotFound", MSyntax::kNoArg);
@@ -176,6 +184,7 @@ MStatus AbcImport::doIt(const MArgList & args)
     bool    swap = false;
     bool    createIfNotFound = false;
     bool    removeIfNoUpdate = false;
+    bool    useFirstAvailableShape = false;
 
     bool    debugOn = false;
 
@@ -187,6 +196,9 @@ MStatus AbcImport::doIt(const MArgList & args)
 
     if (argData.isFlagSet("debug"))
         debugOn = true;
+
+    if (argData.isFlagSet("useFirstAvailableShape"))
+        useFirstAvailableShape = true;
 
     if (argData.isFlagSet("reparent"))
     {
@@ -317,7 +329,8 @@ MStatus AbcImport::doIt(const MArgList & args)
         {
             ArgData inputData(filenameList, debugOn, reparentObj,
                 swap, connectRootNodes, createIfNotFound, removeIfNoUpdate,
-                recreateColorSets, filterString, excludeFilterString);
+                recreateColorSets, filterString, excludeFilterString,
+                useFirstAvailableShape);
             abcNodeName = createScene(inputData);
 
             if (inputData.mSequenceStartTime != inputData.mSequenceEndTime &&

--- a/maya/AbcImport/CreateSceneHelper.cpp
+++ b/maya/AbcImport/CreateSceneHelper.cpp
@@ -361,9 +361,11 @@ namespace
 CreateSceneVisitor::CreateSceneVisitor(double iFrame,
     bool iUnmarkedFaceVaryingColors, const MObject & iParent,
     Action iAction, MString iRootNodes,
-    MString iIncludeFilterString, MString iExcludeFilterString) :
+    MString iIncludeFilterString, MString iExcludeFilterString,
+    bool useFirstAvailableShape) :
     mFrame(iFrame), mParent(iParent),
-    mUnmarkedFaceVaryingColors(iUnmarkedFaceVaryingColors), mAction(iAction)
+    mUnmarkedFaceVaryingColors(iUnmarkedFaceVaryingColors), mAction(iAction),
+    mUseFirstAvailableShape(useFirstAvailableShape)
 {
     mAnyRoots = false;
 
@@ -841,7 +843,8 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::ICamera & iNode)
     bool hasDag = false;
     if (mAction != NONE && mConnectDagNode.isValid())
     {
-        hasDag = getDagPathByChildName(mConnectDagNode, iNode.getName());
+        hasDag = hasDag = getDagPathByChildName(
+            mConnectDagNode, iNode.getName(), mUseFirstAvailableShape);
         if (hasDag)
         {
             cameraObj = mConnectDagNode.node();
@@ -939,7 +942,8 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::ICurves & iNode)
     bool hasDag = false;
     if (mAction != NONE && mConnectDagNode.isValid())
     {
-        hasDag = getDagPathByChildName(mConnectDagNode, iNode.getName());
+        hasDag = getDagPathByChildName(
+            mConnectDagNode, iNode.getName(), mUseFirstAvailableShape);
         if (hasDag)
         {
             curvesObj = mConnectDagNode.node();
@@ -1043,7 +1047,8 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::IPoints& iNode)
     bool hasDag = false;
     if (mAction != NONE && mConnectDagNode.isValid())
     {
-        hasDag = getDagPathByChildName(mConnectDagNode, iNode.getName());
+        hasDag = getDagPathByChildName(
+            mConnectDagNode, iNode.getName(), mUseFirstAvailableShape);
         if (hasDag)
         {
             particleObj = mConnectDagNode.node();
@@ -1124,7 +1129,8 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::ISubD& iNode)
     bool hasDag = false;
     if (mAction != NONE && mConnectDagNode.isValid())
     {
-        hasDag = getDagPathByChildName(mConnectDagNode, iNode.getName());
+        hasDag = getDagPathByChildName(
+            mConnectDagNode, iNode.getName(), mUseFirstAvailableShape);
         if (hasDag)
         {
             subDObj = mConnectDagNode.node();
@@ -1239,7 +1245,8 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::IPolyMesh& iNode)
     bool hasDag = false;
     if (mAction != NONE && mConnectDagNode.isValid())
     {
-        hasDag = getDagPathByChildName(mConnectDagNode, iNode.getName());
+        hasDag = getDagPathByChildName(
+            mConnectDagNode, iNode.getName(), mUseFirstAvailableShape);
         if (hasDag)
         {
             polyObj = mConnectDagNode.node();
@@ -1345,7 +1352,8 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::INuPatch& iNode)
     bool hasDag = false;
     if (mAction != NONE && mConnectDagNode.isValid())
     {
-        hasDag = getDagPathByChildName(mConnectDagNode, iNode.getName());
+        hasDag = getDagPathByChildName(
+            mConnectDagNode, iNode.getName(), mUseFirstAvailableShape);
         if (hasDag)
         {
             nurbsObj = mConnectDagNode.node();
@@ -1441,8 +1449,8 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::IXform & iNode,
             bool hasDag = false;
             if (mAction != NONE && mConnectDagNode.isValid())
             {
-                hasDag = getDagPathByChildName(mConnectDagNode,
-                    iNode.getName());
+                hasDag = getDagPathByChildName(
+                    mConnectDagNode, iNode.getName(), false);
                 if (hasDag)
                 {
                     xformObj = mConnectDagNode.node();
@@ -1516,7 +1524,8 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::IXform & iNode,
         bool hasDag = false;
         if (mAction != NONE && mConnectDagNode.isValid())
         {
-            hasDag = getDagPathByChildName(mConnectDagNode, iNode.getName());
+            hasDag = getDagPathByChildName(
+                mConnectDagNode, iNode.getName(), false);
             if (hasDag)
             {
                 xformObj = mConnectDagNode.node();
@@ -1654,7 +1663,8 @@ MStatus CreateSceneVisitor::createEmptyObject(AlembicObjectPtr iNodeObject)
 
     if (mAction != NONE && mConnectDagNode.isValid())
     {
-        hasDag = getDagPathByChildName(mConnectDagNode, iNode.getName());
+        hasDag = getDagPathByChildName(
+            mConnectDagNode, iNode.getName(), false);
         if (hasDag)
         {
             xformObj = mConnectDagNode.node();

--- a/maya/AbcImport/CreateSceneHelper.h
+++ b/maya/AbcImport/CreateSceneHelper.h
@@ -104,7 +104,8 @@ public:
         const MObject & iParent = MObject::kNullObj,
         Action iAction = CREATE, MString iRootNodes = MString(),
         MString iFilterString = MString(),
-        MString iExcludeFilterString = MString());
+        MString iExcludeFilterString = MString(),
+        bool useFirstAvailableShape = false);
 
     ~CreateSceneVisitor();
 
@@ -164,6 +165,8 @@ private:
     // without the appropriate metadata hint should be treated as a color
     // set (if true) or as an attribute on the node (if false)
     bool mUnmarkedFaceVaryingColors;
+
+    bool mUseFirstAvailableShape;
 
     MDagPath mConnectDagNode;
 

--- a/maya/AbcImport/NodeIteratorVisitorHelper.cpp
+++ b/maya/AbcImport/NodeIteratorVisitorHelper.cpp
@@ -2814,7 +2814,8 @@ ArgData::ArgData(std::vector<std::string>& iFileNames,
     bool iDebugOn, MObject iReparentObj, bool iConnect,
     MString iConnectRootNodes, bool iCreateIfNotFound, bool iRemoveIfNoUpdate,
     bool iRecreateColorSets, MString iFilterString,
-    MString iExcludeFilterString) :
+    MString iExcludeFilterString,
+    bool useFirstAvailableShape) :
         mFileNames(iFileNames),
         mDebugOn(iDebugOn), mReparentObj(iReparentObj),
         mRecreateColorSets(iRecreateColorSets),
@@ -2823,7 +2824,8 @@ ArgData::ArgData(std::vector<std::string>& iFileNames,
         mCreateIfNotFound(iCreateIfNotFound),
         mRemoveIfNoUpdate(iRemoveIfNoUpdate),
         mIncludeFilterString(iFilterString),
-        mExcludeFilterString(iExcludeFilterString)
+        mExcludeFilterString(iExcludeFilterString),
+        mUseFirstAvailableShape(useFirstAvailableShape)
 {
     mSequenceStartTime = -DBL_MAX;
     mSequenceEndTime = DBL_MAX;
@@ -2889,7 +2891,8 @@ MString createScene(ArgData & iArgData)
     CreateSceneVisitor visitor(iArgData.mSequenceStartTime,
         iArgData.mRecreateColorSets, iArgData.mReparentObj, action,
         iArgData.mConnectRootNodes, iArgData.mIncludeFilterString,
-        iArgData.mExcludeFilterString);
+        iArgData.mExcludeFilterString,
+        iArgData.mUseFirstAvailableShape);
 
     visitor.walk(archive);
 

--- a/maya/AbcImport/NodeIteratorVisitorHelper.h
+++ b/maya/AbcImport/NodeIteratorVisitorHelper.h
@@ -251,7 +251,8 @@ public:
         bool    iRemoveIfNoUpdate = false,
         bool    iRecreateColorSets = false,
         MString iIncludeFilterString = MString(""),
-        MString iExcludeFilterString = MString(""));
+        MString iExcludeFilterString = MString(""),
+        bool    useFirstAvailableShape = false);
     ArgData(const ArgData & rhs);
     ArgData & operator=(const ArgData & rhs);
 
@@ -271,6 +272,7 @@ public:
     bool                       mRemoveIfNoUpdate;
     MString                    mIncludeFilterString;
     MString                    mExcludeFilterString;
+    bool                       mUseFirstAvailableShape;
 
     WriterData                 mData;
 };  // ArgData

--- a/maya/AbcImport/util.cpp
+++ b/maya/AbcImport/util.cpp
@@ -300,11 +300,15 @@ std::string stripPathAndNamespace(const std::string & iPath)
     return childName;
 }
 
-bool getDagPathByChildName(MDagPath & ioDagPath, const std::string & iChildName)
+bool getDagPathByChildName(
+    MDagPath & ioDagPath,
+    const std::string & iChildName,
+    bool iUseFirstAvailableShape)
 {
     unsigned int numChildren = ioDagPath.childCount();
     std::string strippedName = stripPathAndNamespace(iChildName);
     MObject closeMatch;
+    MObject firstAvailable;
 
     for (unsigned int i = 0; i < numChildren; ++i)
     {
@@ -324,11 +328,22 @@ bool getDagPathByChildName(MDagPath & ioDagPath, const std::string & iChildName)
                 closeMatch = child;
             }
         }
+
+        if (firstAvailable.isNull())
+        {
+            firstAvailable = child;
+        }
     }
 
     if (!closeMatch.isNull())
     {
         ioDagPath.push(closeMatch);
+        return true;
+    }
+
+    if (iUseFirstAvailableShape && !firstAvailable.isNull())
+    {
+        ioDagPath.push(firstAvailable);
         return true;
     }
 

--- a/maya/AbcImport/util.h
+++ b/maya/AbcImport/util.h
@@ -82,7 +82,8 @@ MStatus getObjectByName(const MString & name, MObject & object);
 MStatus getDagPathByName(const MString & name, MDagPath & dagPath);
 
 bool getDagPathByChildName(MDagPath & ioDagPath,
-    const std::string & iChildName);
+    const std::string & iChildName,
+    bool mUseFirstAvailableShape);
 
 // returns the Maya style leaf name minus the namespace
 std::string stripPathAndNamespace(const std::string & iPath);


### PR DESCRIPTION
It's a simple option which determines if it's necessary to use the first available DAG node of the current parent node when it's not possible to find the DAG node to connect it to the AlembicNode. It can be useful when the Alembic file was exported after Maya renamed the shapes nodes of an object (it happens when deforming reference objects).

This problem happens when a user imports a Maya model as a reference and applies a deformer on that mode. Maya renames a shape of this model to Deformed. Thus, the shape name in Alembic file is also deformed. And it's not possible to connect this geometry to not the deformed model.

It's possible to reproduce the problem like this:

This will create a scene for referencing. It contains objects pSphere1 and pSphereShape1.

```
file -f -new;
polySphere -r 1 -sx 20 -sy 20 -ax 0 1 0 -cuv 2 -ch 1;
file -rename "C:/Temp/sphere.ma";
file -save -type "mayaAscii";
```

Then we create a reference in a new scene. We have sphere:pSphere1 and sphere:pSphereShape1

```
file -f -new;
file -r -namespace "sphere" "C:/Temp/sphere.ma";
select -r sphere:pSphereShape1 ;
```

But as soon as we deform the sphere, Maya renames the shape, so at this step we have sphere:pSphere1 and pShrereShape1Deformed objects. And if we export this scene to Alembic, it will contain pShrereShape1Deformed.

```
nonLinear -type sine -lowBound -1 -highBound 1 -amplitude 1 -wavelength 2 -dropoff 0 -offset 0;
AbcExport -j "-stripNamespaces -dataFormat ogawa -root sphere:pSphere1 -file C:/Temp/sphere.abc";
```

```
C:\>abctree c:\temp\sphere.abc
ABC
 `--pSphere1
     `--pSphereShape1Deformed
```

And it's not possible to connect this Alembic file to the source model:

```
file -f -new;
file -r -namespace "sphere" "C:/Temp/sphere.ma";
AbcImport -mode import -debug -connect "sphere:pSphere1" "C:/Temp/sphere.abc";
// Error: No connection done for node 'pSphereShape1Deformed' with |sphere:pSphere1 // 
```

My solution is a simple option which allows connecting the AlembicNode to the first available shape of the current parent. Usually, in Maya, a transform node contains only one shape and it works perfectly.

I know it's not Alembic problem. It's not even a bug because it works as designed. But since the primary goal of Alembic is caching the animation of geometry, the plugin needs a way to deal with this Maya behavior.
