### PR TITLE
Use Python 2, even when Python 3 is installed on the same system

### DIFF
--- a/cmake/AlembicPython.cmake
+++ b/cmake/AlembicPython.cmake
@@ -33,8 +33,8 @@
 ##
 ##-*****************************************************************************
 
-FIND_PACKAGE ( PythonLibs REQUIRED )
 FIND_PACKAGE ( PythonInterp REQUIRED )
+FIND_PACKAGE ( PythonLibs REQUIRED )
 IF(PYTHONLIBS_FOUND)
     SET(ALEMBIC_PYTHON_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
     SET(ALEMBIC_PYTHON_LIBRARY ${PYTHON_LIBRARIES})

--- a/cmake/AlembicPython.cmake
+++ b/cmake/AlembicPython.cmake
@@ -33,8 +33,8 @@
 ##
 ##-*****************************************************************************
 
-FIND_PACKAGE ( PythonInterp REQUIRED )
-FIND_PACKAGE ( PythonLibs REQUIRED )
+FIND_PACKAGE ( PythonInterp 2 REQUIRED )
+FIND_PACKAGE ( PythonLibs 2 REQUIRED)
 IF(PYTHONLIBS_FOUND)
     SET(ALEMBIC_PYTHON_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
     SET(ALEMBIC_PYTHON_LIBRARY ${PYTHON_LIBRARIES})

--- a/lib/Alembic/AbcGeom/IXform.cpp
+++ b/lib/Alembic/AbcGeom/IXform.cpp
@@ -316,7 +316,7 @@ XformSample IXformSchema::getValue( const Abc::ISampleSelector &iSS ) const
 }
 
 //-*****************************************************************************
-bool IXformSchema::getInheritsXforms( const Abc::ISampleSelector &iSS )
+bool IXformSchema::getInheritsXforms( const Abc::ISampleSelector &iSS ) const
 {
     ALEMBIC_ABC_SAFE_CALL_BEGIN( "IXformSchema::getInheritsXforms()" );
 

--- a/lib/Alembic/AbcGeom/IXform.h
+++ b/lib/Alembic/AbcGeom/IXform.h
@@ -134,7 +134,7 @@ public:
     // lightweight get to avoid constructing a sample
     // see XformSample.h for explanation of this property
     bool getInheritsXforms( const Abc::ISampleSelector &iSS =
-                            Abc::ISampleSelector() );
+                            Abc::ISampleSelector() ) const;
 
     size_t getNumOps() const { return m_sample.getNumOps(); }
 


### PR DESCRIPTION
This PR fixes bug report #108, and makes the CMake file a bit more consistent with what CMake itself suggests (using PythonInterp before PythonLibs).
