### PR TITLE
Fix #110: Made IXform::getInheritsXforms() a const member function

### DIFF
--- a/lib/Alembic/AbcGeom/IXform.cpp
+++ b/lib/Alembic/AbcGeom/IXform.cpp
@@ -316,7 +316,7 @@ XformSample IXformSchema::getValue( const Abc::ISampleSelector &iSS ) const
 }
 
 //-*****************************************************************************
-bool IXformSchema::getInheritsXforms( const Abc::ISampleSelector &iSS )
+bool IXformSchema::getInheritsXforms( const Abc::ISampleSelector &iSS ) const
 {
     ALEMBIC_ABC_SAFE_CALL_BEGIN( "IXformSchema::getInheritsXforms()" );
 

--- a/lib/Alembic/AbcGeom/IXform.h
+++ b/lib/Alembic/AbcGeom/IXform.h
@@ -134,7 +134,7 @@ public:
     // lightweight get to avoid constructing a sample
     // see XformSample.h for explanation of this property
     bool getInheritsXforms( const Abc::ISampleSelector &iSS =
-                            Abc::ISampleSelector() );
+                            Abc::ISampleSelector() ) const;
 
     size_t getNumOps() const { return m_sample.getNumOps(); }
 


### PR DESCRIPTION
Fix for issue #110 

IXform::getInheritsXforms() is documented as a shortcut for `XformSample::getInheritsXforms() const` so that one doesn't have to create a sample object. However, that function is const, while IXform::getInheritsXforms() is not. This commit fixes that.