### PR TITLE
AbcCoreLayer single file IObject  getPropertiesHash, getChildrenHash fix

### DIFF
--- a/lib/Alembic/AbcCoreLayer/OrImpl.cpp
+++ b/lib/Alembic/AbcCoreLayer/OrImpl.cpp
@@ -186,7 +186,8 @@ bool OrImpl::getPropertiesHash( Util::Digest & oDigest )
 
     if ( childVec.size() == 1 )
     {
-        return childVec[0].first->getPropertiesHash( oDigest );
+        const ObjectAndIndex & oi = childVec[0];
+        return oi.first->getChild( oi.second )->getPropertiesHash( oDigest );
     }
 
     return false;
@@ -208,7 +209,8 @@ bool OrImpl::getChildrenHash( Util::Digest & oDigest )
     // has any children
     if ( childVec.size() == 1 )
     {
-        return childVec[0].first->getChildrenHash( oDigest );
+        const ObjectAndIndex & oi = childVec[0];
+        return oi.first->getChild( oi.second )->getChildrenHash( oDigest );
     }
 
     return false;

--- a/lib/Alembic/AbcCoreLayer/Tests/ObjectTests.cpp
+++ b/lib/Alembic/AbcCoreLayer/Tests/ObjectTests.cpp
@@ -240,10 +240,50 @@ void replaceTest()
 }
 
 //-*****************************************************************************
+void hashTest()
+{
+    std::string fileName = "hashTest.abc";
+    {
+        OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), fileName );
+        OObject child( archive.getTop(), "child" );
+        OObject childCool( child, "cool" );
+        OObject childGuy( child, "guy" );
+
+        OCompoundProperty wowProp( child.getProperties(), "wow" );
+        OCompoundProperty amazingProp( wowProp, "amazing" );
+    }
+
+    {
+        std::vector< std::string > files;
+        files.push_back( fileName );
+
+        Alembic::AbcCoreFactory::IFactory factory;
+        IArchive archiveLayer = factory.getArchive( files );
+        IArchive archive = factory.getArchive( fileName );
+
+        Alembic::Util::Digest childHash;
+        IObject child( archive.getTop(), "child" );
+        child.getPropertiesHash( childHash );
+
+        Alembic::Util::Digest childLayerHash;
+        IObject childLayer( archiveLayer.getTop(), "child" );
+        childLayer.getPropertiesHash( childLayerHash );
+
+        TESTING_ASSERT( childHash == childLayerHash );
+
+        child.getChildrenHash( childHash );
+        childLayer.getChildrenHash( childLayerHash );
+
+        TESTING_ASSERT( childHash == childLayerHash );
+    }
+}
+
+//-*****************************************************************************
 int main( int argc, char *argv[] )
 {
     layerTest();
     pruneTest();
     replaceTest();
+    hashTest();
     return 0;
 }


### PR DESCRIPTION
Fix bug where the properties and child hashes were returning the wrong value for AbcCoreLayer archives that only have one file passed in.

Add a test for it too.