### PR TITLE
Pass point widths to PRMan procedural

### DIFF
--- a/prman/Procedural/WriteGeo.cpp
+++ b/prman/Procedural/WriteGeo.cpp
@@ -682,6 +682,35 @@ void ProcessPoints( IPoints &points, ProcArgs &args )
         
         ParamListBuilder paramListBuilder;
         paramListBuilder.add( "P", (RtPointer)sample.getPositions()->get() );
+
+        IFloatGeomParam widthParam = ps.getWidthsParam();
+        if ( widthParam.valid() )
+        {
+            ICompoundProperty parent = widthParam.getParent();
+            
+            //prman requires "width" to be named "constantwidth" when
+            //constant instead of declared as "constant float width".
+            //It's even got an error message specifically for it.
+            std::string widthName;
+            if ( widthParam.getScope() == kConstantScope ||
+                    widthParam.getScope() == kUnknownScope )
+            {
+                widthName = "constantwidth";
+            }
+            else
+            {
+                widthName = "width";
+            }
+            
+            AddGeomParamToParamListBuilder<IFloatGeomParam>(
+                parent,
+                widthParam.getHeader(),
+                sampleSelector,
+                "float",
+                paramListBuilder,
+                1,
+                widthName);
+        }
         
         ICompoundProperty arbGeomParams = ps.getArbGeomParams();
         AddArbitraryGeomParams( arbGeomParams,


### PR DESCRIPTION
RiPoints, like RiCurves, allow for constant/varying point width attributes. This PR copies the width handling code from ProcessCurves() so that RiPoints will have their widths set as well.

Reference:
[Pixar RenderMan Docs](https://renderman.pixar.com/resources/RenderMan_20/geometricPrimitives.html#point-and-curve-primitives)


