### PR TITLE
Add RMan Proc visibility support for PolyMesh

### DIFF
--- a/prman/Procedural/ProcMain.cpp
+++ b/prman/Procedural/ProcMain.cpp
@@ -185,7 +185,10 @@ void WalkObject( IObject parent, const ObjectHeader &ohead, ProcArgs &args,
 #ifdef PRMAN_USE_ABCMATERIAL
             ApplyObjectMaterial(polymesh, args );
 #endif
-        ProcessPolyMesh( polymesh, args );
+        if ( visible )
+        {
+            ProcessPolyMesh( polymesh, args );
+        }
 
         nextParentObject = polymesh;
     }


### PR DESCRIPTION
PolyMesh visibility support was missing when compared to the other geometry types that the RenderMan procedural supports. This PR adds a visible check so PolyMeshes will now be consistent with the other types.
