### PR TITLE
Layering optimizations

### DIFF
--- a/lib/Alembic/AbcCoreFactory/IFactory.cpp
+++ b/lib/Alembic/AbcCoreFactory/IFactory.cpp
@@ -125,6 +125,12 @@ Alembic::Abc::IArchive IFactory::getArchive(
 Alembic::Abc::IArchive IFactory::getArchive(
     const std::vector< std::string > & iFileNames, CoreType & oType )
 {
+    // Skip layering in case of a single input file
+    if(iFileNames.size() == 1)
+    {
+        return getArchive(iFileNames[0], oType);
+    }
+
     Alembic::AbcCoreLayer::ReadArchive layer;
 
     Alembic::AbcCoreLayer::ArchiveReaderPtrs archives;

--- a/lib/Alembic/AbcCoreLayer/CprImpl.cpp
+++ b/lib/Alembic/AbcCoreLayer/CprImpl.cpp
@@ -183,6 +183,12 @@ CprImpl::getCompoundProperty( const std::string &iName )
 
     if( itr != m_childNameMap.end() )
     {
+        CompoundReaderPtrs childVec = m_children[ itr->second ];
+        if ( childVec.size() == 1 )
+        {
+            return childVec[0]->getCompoundProperty( itr->first );
+        }
+
         return CprImplPtr( new CprImpl( shared_from_this(), itr->second ) );
     }
 

--- a/lib/Alembic/AbcCoreLayer/OrImpl.cpp
+++ b/lib/Alembic/AbcCoreLayer/OrImpl.cpp
@@ -150,6 +150,17 @@ AbcA::ObjectReaderPtr OrImpl::getChild( const std::string &iName )
 
     if( findChildItr != m_childNameMap.end() )
     {
+        // if the child comes from a single layer just return
+        // it from the impl
+        const std::vector< ObjectAndIndex >& childVec =
+            m_children[findChildItr->second];
+
+        if ( childVec.size() == 1 )
+        {
+            const ObjectAndIndex& oi = childVec[0];
+            return oi.first->getChild( oi.second );
+        }
+
         return OrImplPtr( new OrImpl( shared_from_this(),
                                       findChildItr->second ) );
     }
@@ -161,7 +172,26 @@ AbcA::ObjectReaderPtr OrImpl::getChild( size_t i )
 {
     if ( i < m_childHeaders.size() )
     {
-        return OrImplPtr( new OrImpl( shared_from_this(), i ) );
+        ObjectHeaderPtr headerPtr = m_childHeaders[i];
+        ChildNameMap::iterator findChildItr =
+            m_childNameMap.find(headerPtr->getName());
+
+        if ( findChildItr != m_childNameMap.end() )
+        {
+            // if the child comes from a single layer just return
+            // it from the impl
+            const std::vector< ObjectAndIndex >& childVec =
+                m_children[findChildItr->second];
+
+            if ( childVec.size() == 1 )
+            {
+                const ObjectAndIndex& oi = childVec[0];
+                return oi.first->getChild( oi.second );
+            }
+        }
+
+        return OrImplPtr( new OrImpl( shared_from_this(), i ));
+
     }
 
     return AbcA::ObjectReaderPtr();


### PR DESCRIPTION
This pull request makes the following changes in regards to `AbcCoreLayer`:

1. If a `std::vector` with 1 element is provided to `IFactory::getArchive` `AbcCoreLayer` will be bypassed and use `AbcCoreOgawa` or `AbcCoreHdf5`.
2. `AbcCoreLayer::OrImpl` and `AbcCoreLayer::CprImpl` will return the actual Impl if there is only one child (layer).

The first change is just an optimization if `AbcCoreLayer` is not needed. The second change helps prevent unnecessary heap allocations for archives that have significant instancing.