### PR TITLE
Fixed the issue about pread() on OSX for super large array at once

### DIFF
--- a/lib/Alembic/Ogawa/IStreams.cpp
+++ b/lib/Alembic/Ogawa/IStreams.cpp
@@ -176,7 +176,7 @@ public:
         for (size_t i = 0; i < numChunk; ++ i)
         {
             size_t chunkSize = chunkSizes[i];
-            size_t numRead = pread(fd, buf, chunkSize, offset);
+            ssize_t numRead = pread(fd, buf, chunkSize, offset);
             if (numRead > 0)
             {
                 totalRead += numRead;

--- a/lib/Alembic/Ogawa/IStreams.cpp
+++ b/lib/Alembic/Ogawa/IStreams.cpp
@@ -152,18 +152,42 @@ public:
         }
         while(numRead > 0 && totalRead < iSize);
 #else
-        ssize_t numRead = 0;
-        do
+        // 256M bytes as a safe chunk.
+        // The pread() could not read 2G+ data at once on OSX.
+        static const size_t kChunkSize = 256 * 1024 * 1024;
+
+        // Count how many huge chunks do we have.
+        size_t numChunk = iSize / kChunkSize;
+        size_t *chunkSizes = static_cast<size_t *>(alloca((numChunk + 1) * sizeof(size_t)));
+        for (size_t i = 0; i < numChunk; ++ i)
         {
-            numRead = pread(fd, buf, iSize - totalRead, offset);
+            chunkSizes[i] = kChunkSize;
+        }
+
+        // Append the size of last chunk.
+        size_t lastChunkSize = iSize % kChunkSize;
+        if (lastChunkSize)
+        {
+            numChunk += 1;
+            chunkSizes[numChunk - 1] = lastChunkSize;
+        }
+
+        // Read each chunk.
+        for (size_t i = 0; i < numChunk; ++ i)
+        {
+            size_t chunkSize = chunkSizes[i];
+            size_t numRead = pread(fd, buf, chunkSize, offset);
             if (numRead > 0)
             {
                 totalRead += numRead;
                 offset += numRead;
                 buf = static_cast< char * >( buf ) + numRead;
             }
+            else
+            {
+                break;
+            }
         }
-        while(numRead > 0 && totalRead < iSize);
 #endif
 
         // if we couldn't read what we needed to then something went wrong


### PR DESCRIPTION
Hi,

We have a super large single P sample which is larger than 2G, and it could not be read on OSX around the pread() from Ogawa::IStream::read(). This doesn't happen on Windows or Linux but OSX only.

This PR would propose the way to split the large array into several chunks then read them into buffer.

Please have a look, thanks.