### PR TITLE
Make the file order consistent between property layering and prune/replace operation.

### DIFF
--- a/lib/Alembic/AbcCoreLayer/ArImpl.cpp
+++ b/lib/Alembic/AbcCoreLayer/ArImpl.cpp
@@ -50,9 +50,10 @@ ArImpl::ArImpl( ArchiveReaderPtrs & iArchives )
     m_archiveVersion = -1;
     m_header.reset( new AbcA::ObjectHeader() );
     m_archives.reserve( iArchives.size() );
-    ArchiveReaderPtrs::iterator it = iArchives.begin();
+    ArchiveReaderPtrs::reverse_iterator it = iArchives.rbegin();
 
-    for ( ; it != iArchives.end(); ++it )
+    // reverse them here so OrImpl goes fwds
+    for ( ; it != iArchives.rend(); ++it )
     {
         // bad archive ptr?  skip to the next one
         if ( !( *it ) )

--- a/lib/Alembic/AbcCoreLayer/CprImpl.cpp
+++ b/lib/Alembic/AbcCoreLayer/CprImpl.cpp
@@ -269,8 +269,22 @@ void CprImpl::init( CompoundReaderPtrs & iCompounds )
 
                 m_children[ index ].push_back( *it );
 
+                m_propertyHeaders[ index ] = PropertyHeaderPtr(
+                    new AbcA::PropertyHeader( propHeader ) );
+
                 // TODO, are there cases where the MetaData should be combined
                 // for Compound properties?
+            }
+
+            // for cases where we have a simple property type, or the property
+            // type is different
+            else
+            {
+                size_t index = nameIt->second;
+                m_children[ index ].clear();
+                m_children[ index ].push_back( *it );
+                m_propertyHeaders[ index ] = PropertyHeaderPtr(
+                    new AbcA::PropertyHeader( propHeader ) );
             }
         }
     }

--- a/lib/Alembic/AbcCoreLayer/CprImpl.h
+++ b/lib/Alembic/AbcCoreLayer/CprImpl.h
@@ -100,14 +100,18 @@ private:
 
     size_t m_index;
 
-    // this compounds header
-    PropertyHeaderPtr m_header;
+    // we need to own the PropertyHeader on the top compounds
+    // (which have no parents), others we can get from
+    // m_children and m_childHeaderIndex below
+    PropertyHeaderPtr m_topHeader;
 
     // each child is made up of the original parent compound, array and scalar
     // properties will only have 1 entry, compounds could have more
     std::vector< CompoundReaderPtrs > m_children;
 
-    std::vector< PropertyHeaderPtr > m_propertyHeaders;
+    // so we don't have to copy property headers over, keep track of what
+    // index to use for the header from the appropriate parent in m_children
+    std::vector< size_t > m_childHeaderIndex;
 
     ChildNameMap m_childNameMap;
 };

--- a/lib/Alembic/AbcCoreLayer/Tests/ObjectTests.cpp
+++ b/lib/Alembic/AbcCoreLayer/Tests/ObjectTests.cpp
@@ -279,11 +279,68 @@ void hashTest()
 }
 
 //-*****************************************************************************
+void pruneAndAddTest()
+{
+    std::string fileName = "objectPruneAndAdd1.abc";
+    std::string fileName2 = "objectPruneAndAdd2.abc";
+
+    {
+        // add xform1 with polymesh and curve children
+        OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), fileName );
+        OObject xform1( archive.getTop(), "xform1" );
+        OObject xform1Poly( xform1, "polymesh" );
+        OObject xform1Curve( xform1, "curve" );
+    }
+
+    {
+        MetaData md;
+        Alembic::AbcCoreLayer::SetPrune( md, true );
+
+        OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), fileName2 );
+
+        // create placeholder xform1, and then curve which will be pruned
+        OObject xform1( archive.getTop(), "xform1" );
+        OObject xform1Curve( xform1, "curve", md);
+
+        // add xform2 with polymesh and curve children
+        OObject xform2( archive.getTop(), "xform2" );
+        OObject xform2Poly( xform2, "polymesh" );
+        OObject xform2Curve( xform2, "curve" );
+    }
+
+    {
+        std::vector< std::string > files;
+        files.push_back( fileName );
+        files.push_back( fileName2 );
+
+        Alembic::AbcCoreFactory::IFactory factory;
+        IArchive archive = factory.getArchive( files );
+
+        IObject root = archive.getTop();
+
+        // xform1 and xform2
+        TESTING_ASSERT( root.getNumChildren() == 2 );
+
+        // xform1 just has polymesh (curve has been pruned)
+        IObject xform1( root, "xform1" );
+        TESTING_ASSERT( xform1.getNumChildren() == 1 );
+        TESTING_ASSERT( IObject( xform1, "polymesh" ).valid() );
+
+        // xform2 has polymesh and curve
+        IObject xform2( root, "xform2" );
+        TESTING_ASSERT( xform2.getNumChildren() == 2 );
+        TESTING_ASSERT( IObject( xform2, "polymesh" ).valid() );
+        TESTING_ASSERT( IObject( xform2, "curve" ).valid() );
+    }
+}
+
+//-*****************************************************************************
 int main( int argc, char *argv[] )
 {
     layerTest();
     pruneTest();
     replaceTest();
     hashTest();
+    pruneAndAddTest();
     return 0;
 }

--- a/lib/Alembic/AbcCoreLayer/Tests/ObjectTests.cpp
+++ b/lib/Alembic/AbcCoreLayer/Tests/ObjectTests.cpp
@@ -71,8 +71,8 @@ void layerTest()
 
     {
         std::vector< std::string > files;
-        files.push_back( fileName );
         files.push_back( fileName2 );
+        files.push_back( fileName );
 
         Alembic::AbcCoreFactory::IFactory factory;
         IArchive archive = factory.getArchive( files );
@@ -136,8 +136,8 @@ void pruneTest()
 
     {
         std::vector< std::string > files;
-        files.push_back( fileName );
         files.push_back( fileName2 );
+        files.push_back( fileName );
 
         Alembic::AbcCoreFactory::IFactory factory;
         IArchive archive = factory.getArchive( files );
@@ -199,8 +199,8 @@ void replaceTest()
 
     {
         std::vector< std::string > files;
-        files.push_back( fileName );
         files.push_back( fileName2 );
+        files.push_back( fileName );
 
         Alembic::AbcCoreFactory::IFactory factory;
         IArchive archive = factory.getArchive( files );
@@ -310,8 +310,8 @@ void pruneAndAddTest()
 
     {
         std::vector< std::string > files;
-        files.push_back( fileName );
         files.push_back( fileName2 );
+        files.push_back( fileName );
 
         Alembic::AbcCoreFactory::IFactory factory;
         IArchive archive = factory.getArchive( files );

--- a/lib/Alembic/AbcGeom/Tests/CMakeLists.txt
+++ b/lib/Alembic/AbcGeom/Tests/CMakeLists.txt
@@ -122,7 +122,7 @@ ADD_TEST(AbcGeom_LightTest_TEST AbcGeom_LightTest)
 ADD_EXECUTABLE(AbcGeom_CameraTest
                CameraTest.cpp)
 TARGET_LINK_LIBRARIES(AbcGeom_CameraTest Alembic)
-ADD_TEST(AbcGeom_Points_TEST AbcGeom_CameraTest)
+ADD_TEST(AbcGeom_Camera_TEST AbcGeom_CameraTest)
 
 ADD_EXECUTABLE(playground PlayGround.cpp)
 TARGET_LINK_LIBRARIES(playground Alembic)

--- a/lib/Alembic/AbcGeom/Tests/CameraTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/CameraTest.cpp
@@ -326,8 +326,8 @@ void sparseTest()
 
     {
         std::vector< std::string > names;
-        names.push_back( fileA );
         names.push_back( fileB );
+        names.push_back( fileA );
         Alembic::AbcCoreFactory::IFactory factory;
         IArchive archive = factory.getArchive( names );
 

--- a/lib/Alembic/AbcGeom/Tests/XformTests.cpp
+++ b/lib/Alembic/AbcGeom/Tests/XformTests.cpp
@@ -541,8 +541,8 @@ void sparseTest()
 
     {
         std::vector< std::string > names;
-        names.push_back( nameA );
         names.push_back( nameB );
+        names.push_back( nameA );
         Alembic::AbcCoreFactory::IFactory factory;
         IArchive archive = factory.getArchive( names );
 

--- a/maya/AbcImport/AbcImport.cpp
+++ b/maya/AbcImport/AbcImport.cpp
@@ -105,7 +105,7 @@ AbcImport -h;                                                               \n\
 AbcImport -d -m open \"/tmp/test.abc\";                                     \n\
 AbcImport -ftr -ct \"/\" -crt -rm \"/tmp/test.abc\";                        \n\
 AbcImport -ct \"root1 root2 root3 ...\" \"/tmp/test.abc\";                  \n\
-AbcImport \"/tmp/test.abc\" \"/tmp/justUVs.abc\" \"/tmp/other.abc\"         \n"
+AbcImport \"/tmp/sparseAnimPts.abc\" \"/tmp/justUVs.abc\" \"/tmp/base.abc\" \n"
 );  // usage
 
 };


### PR DESCRIPTION
There was a bug where layering properties worked with one order, but the prune and replace for IObjects and ICompoundProperties worked with another order.

Since layering the properties is the most commonly used case we will adopt that ordering.

The unified ordering canonical example is:
sparseAnimatedPoints.abc sparseUVs.abc base.abc

Where base.abc is the original model, sparseUvs.abc may contain new UVs, and
sparseAnimatedPoints.abc may contain the animated samples.