### PR TITLE
Avoid using headers with empty MetaData when combining Compound properties.

### DIFF
--- a/lib/Alembic/AbcCoreLayer/CprImpl.cpp
+++ b/lib/Alembic/AbcCoreLayer/CprImpl.cpp
@@ -261,9 +261,10 @@ void CprImpl::init( CompoundReaderPtrs & iCompounds )
             // only add this onto an existing one IF its a compound and the
             // prop added previously is a compound
             else if ( propHeader.isCompound() &&
-                      m_children[ nameIt->second ][
-                        m_childHeaderIndex[ nameIt->second ].first ]->getPropertyHeader(
-                        m_childHeaderIndex[ nameIt->second ].second ).isCompound() )
+                      m_children[ nameIt->second ][ m_childHeaderIndex[
+                            nameIt->second ].first ]->getPropertyHeader(
+                                m_childHeaderIndex[ nameIt->second ].second
+                            ).isCompound() )
             {
                 // add parent and index to the existing child element, and then
                 // update the MetaData
@@ -280,7 +281,8 @@ void CprImpl::init( CompoundReaderPtrs & iCompounds )
                 // on a compound to override existing non empty metadata
                 if ( propHeader.getMetaData().size() != 0 )
                 {
-                    m_childHeaderIndex[ index ].first = m_children[ index ].size() - 1;
+                    m_childHeaderIndex[ index ].first =
+                        m_children[ index ].size() - 1;
                     m_childHeaderIndex[ index ].second = i;
                 }
             }

--- a/lib/Alembic/AbcCoreLayer/CprImpl.cpp
+++ b/lib/Alembic/AbcCoreLayer/CprImpl.cpp
@@ -134,7 +134,8 @@ const AbcA::PropertyHeader & CprImpl::getPropertyHeader( size_t i )
     ABCA_ASSERT( i < m_children.size(),
         "Out of range index in CprImpl::getPropertyHeader: " << i );
 
-    return m_children[ i ].back()->getPropertyHeader( m_childHeaderIndex[ i ] );
+    return m_children[ i ][ m_childHeaderIndex[ i ].first ]->getPropertyHeader(
+        m_childHeaderIndex[ i ].second );
 }
 
 //-*****************************************************************************
@@ -146,8 +147,9 @@ CprImpl::getPropertyHeader( const std::string &iName )
 
     if( itr !=  m_childNameMap.end() )
     {
-        return &( m_children[ itr->second ].back()->getPropertyHeader(
-                  m_childHeaderIndex[ itr->second ] ) );
+        return &( m_children[ itr->second ][
+            m_childHeaderIndex[ itr->second ].first ]->getPropertyHeader(
+                m_childHeaderIndex[ itr->second ].second ) );
     }
 
     return 0;
@@ -232,7 +234,7 @@ void CprImpl::init( CompoundReaderPtrs & iCompounds )
 
                 m_children.resize( index + 1 );
                 m_children[ index ].push_back( *it );
-                m_childHeaderIndex.push_back( i );
+                m_childHeaderIndex.push_back( HeaderIndexPair( 0, i ) );
                 continue;
             }
             // prune
@@ -259,8 +261,9 @@ void CprImpl::init( CompoundReaderPtrs & iCompounds )
             // only add this onto an existing one IF its a compound and the
             // prop added previously is a compound
             else if ( propHeader.isCompound() &&
-                      m_children[ nameIt->second ].back()->getPropertyHeader(
-                        m_childHeaderIndex[ nameIt->second ] ).isCompound() )
+                      m_children[ nameIt->second ][
+                        m_childHeaderIndex[ nameIt->second ].first ]->getPropertyHeader(
+                        m_childHeaderIndex[ nameIt->second ].second ).isCompound() )
             {
                 // add parent and index to the existing child element, and then
                 // update the MetaData
@@ -272,8 +275,14 @@ void CprImpl::init( CompoundReaderPtrs & iCompounds )
                 }
 
                 m_children[ index ].push_back( *it );
-                m_childHeaderIndex[ index ] = i;
 
+                // for special case sparse hiearchies we don't want empty meta data
+                // on a compound to override existing non empty metadata
+                if ( propHeader.getMetaData().size() != 0 )
+                {
+                    m_childHeaderIndex[ index ].first = m_children[ index ].size() - 1;
+                    m_childHeaderIndex[ index ].second = i;
+                }
             }
 
             // for cases where we have a simple property type, or the property
@@ -283,7 +292,8 @@ void CprImpl::init( CompoundReaderPtrs & iCompounds )
                 size_t index = nameIt->second;
                 m_children[ index ].clear();
                 m_children[ index ].push_back( *it );
-                m_childHeaderIndex[ index ] = i;
+                m_childHeaderIndex[ index ].first = 0;
+                m_childHeaderIndex[ index ].second = i;
             }
         }
     }

--- a/lib/Alembic/AbcCoreLayer/CprImpl.h
+++ b/lib/Alembic/AbcCoreLayer/CprImpl.h
@@ -111,7 +111,8 @@ private:
 
     // so we don't have to copy property headers over, keep track of what
     // index to use for the header from the appropriate parent in m_children
-    std::vector< size_t > m_childHeaderIndex;
+    typedef std::pair< size_t, size_t > HeaderIndexPair;
+    std::vector< HeaderIndexPair > m_childHeaderIndex;
 
     ChildNameMap m_childNameMap;
 };

--- a/lib/Alembic/AbcGeom/Tests/CurvesTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/CurvesTest.cpp
@@ -247,11 +247,11 @@ void sparseTest()
         IObject curveUVsObj( IObject( archive, kTop ), "curveUVs" );
 
         // This should NOT match
-        TESTING_ASSERT( !IPolyMeshSchema::matches( curveUVsObj.getMetaData() ) );
+        TESTING_ASSERT( !ICurvesSchema::matches( curveUVsObj.getMetaData() ) );
         ICompoundProperty geomProp( curveUVsObj.getProperties(), ".geom" );
 
         // This shouldn't match either
-        TESTING_ASSERT( !IPolyMeshSchema::matches( geomProp.getMetaData() ) );
+        TESTING_ASSERT( !ICurvesSchema::matches( geomProp.getMetaData() ) );
 
         // and we should ONLY have UVs
         TESTING_ASSERT( geomProp.getNumProperties() == 1 &&
@@ -263,11 +263,11 @@ void sparseTest()
         IObject curvePosObj( IObject( archive, kTop ), "curvePositions" );
 
         // This should NOT match
-        TESTING_ASSERT( !IPolyMeshSchema::matches( curvePosObj.getMetaData() ) );
+        TESTING_ASSERT( !ICurvesSchema::matches( curvePosObj.getMetaData() ) );
         geomProp = ICompoundProperty( curvePosObj.getProperties(), ".geom" );
 
         // This shouldn't match either
-        TESTING_ASSERT( !IPolyMeshSchema::matches( geomProp.getMetaData() ) );
+        TESTING_ASSERT( !ICurvesSchema::matches( geomProp.getMetaData() ) );
         TESTING_ASSERT( geomProp.getNumProperties() == 2 &&
             geomProp.getPropertyHeader("P") != NULL &&
             geomProp.getPropertyHeader(".selfBnds") != NULL );

--- a/lib/Alembic/AbcGeom/Tests/XformTests.cpp
+++ b/lib/Alembic/AbcGeom/Tests/XformTests.cpp
@@ -571,6 +571,55 @@ void sparseTest()
 }
 
 //-*****************************************************************************
+void sparseTest2()
+{
+    XformOp scaleOp( kScaleOperation, kScaleHint );
+
+    std::string nameA = "sparseXformTest2A.abc";
+    {
+        OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), nameA );
+
+        OXform axform( OObject( archive ),  "a" );
+        OXform bxform( axform, "b" );
+        OXform cxform( bxform, "c" );
+    }
+
+    std::string nameB = "sparseXformTest2B.abc";
+    {
+        OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), nameB );
+        OObject axform( OObject( archive ),  "a" );
+        OObject bxform( axform, "b" );
+        OXform cxform( bxform, "c" );
+        XformSample csamp;
+        csamp.addOp( scaleOp, V3d( 0.5, 0.5, 0.5 ) );
+        cxform.getSchema().set( csamp );
+    }
+
+    {
+        std::vector< std::string > names;
+        names.push_back( nameB );
+        names.push_back( nameA );
+        Alembic::AbcCoreFactory::IFactory factory;
+        IArchive archive = factory.getArchive( names );
+
+        IObject aobj( IObject( archive ), "a" );
+        TESTING_ASSERT( IXform::matches( aobj.getHeader() ) );
+        IXform axform( IObject( archive ), "a" );
+        TESTING_ASSERT( axform.getSchema().isConstantIdentity() );
+
+        IObject bobj( aobj, "b" );
+        TESTING_ASSERT( IXform::matches( bobj.getHeader() ) );
+        IXform bxform( aobj, "a" );
+        TESTING_ASSERT( bxform.getSchema().isConstantIdentity() );
+
+        IObject cobj( bobj, "c" );
+        TESTING_ASSERT( IXform::matches( cobj.getHeader() ) );
+        IXform cxform( bobj, "c" );
+        TESTING_ASSERT( !cxform.getSchema().isConstantIdentity() );
+    }
+}
+
+//-*****************************************************************************
 int main( int argc, char *argv[] )
 {
     xformOut();
@@ -578,5 +627,6 @@ int main( int argc, char *argv[] )
     someOpsXform();
     xformTreeCreate();
     sparseTest();
+    sparseTest2();
     return 0;
 }

--- a/lib/Alembic/AbcGeom/Tests/XformTests.cpp
+++ b/lib/Alembic/AbcGeom/Tests/XformTests.cpp
@@ -609,7 +609,7 @@ void sparseTest2()
 
         IObject bobj( aobj, "b" );
         TESTING_ASSERT( IXform::matches( bobj.getHeader() ) );
-        IXform bxform( aobj, "a" );
+        IXform bxform( aobj, "b" );
         TESTING_ASSERT( bxform.getSchema().isConstantIdentity() );
 
         IObject cobj( bobj, "c" );


### PR DESCRIPTION
When combining compound properties, don't use property headers that have no meta data to make it easier to combine sparse hierarchies.