### PR TITLE
[cmake] Ability to specify where to install the alembic libs from the commandline

### DIFF
--- a/lib/Alembic/CMakeLists.txt
+++ b/lib/Alembic/CMakeLists.txt
@@ -84,11 +84,12 @@ IF ( ${ALEMBIC_LIB_USES_TR1} AND CMAKE_COMPILER_IS_GNUCXX AND
     TARGET_LINK_LIBRARIES( Alembic atomic )
 ENDIF()
 
+SET( ALEMBIC_LIB_INSTALL_DIR lib CACHE PATH "Where to install the Alembic libs")
 INSTALL(TARGETS Alembic
         EXPORT AlembicTargets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION lib)
+        LIBRARY DESTINATION ${ALEMBIC_LIB_INSTALL_DIR}
+        ARCHIVE DESTINATION ${ALEMBIC_LIB_INSTALL_DIR}
+        RUNTIME DESTINATION ${ALEMBIC_LIB_INSTALL_DIR})
 
 #-******************************************************************************
 # PACKAGE EXPORTS

--- a/lib/Alembic/CMakeLists.txt
+++ b/lib/Alembic/CMakeLists.txt
@@ -117,7 +117,9 @@ EXPORT(TARGETS
     Alembic::
     )
 
-SET(ConfigPackageLocation lib/cmake/Alembic)
+SET(ConfigPackageLocation lib/cmake/Alembic CACHE PATH
+    "Where to install the Alembic's cmake files")
+
 INSTALL(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/AlembicConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/AlembicConfigVersion.cmake"


### PR DESCRIPTION
Small patch to the lib's CMakeLists.txt file to have the ability to specify where it should place the libs and cmake package files when building the core libraries for alembic. 

Useful if you want to split the dynamic and static libraries apart. For example place the static one in a subdirectory. Or use lib64 instead of lib.

Thanks
