### PR TITLE
[cmake] Ability to specify where to install the python module from the cli

### DIFF
--- a/python/PyAlembic/CMakeLists.txt
+++ b/python/PyAlembic/CMakeLists.txt
@@ -127,8 +127,14 @@ IF (Boost_PYTHON_LIBRARY AND ALEMBIC_PYTHON_LIBRARY)
         PROPERTIES PREFIX "" SUFFIX ".so"
     )
 
+    SET( ALEMBIC_PYTHON_INSTALL_DIR
+        lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages
+        CACHE PATH
+        "Alembic's python bindings install directory"
+    )
+
     INSTALL (TARGETS alembic
-        DESTINATION lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages
+        DESTINATION ${ALEMBIC_PYTHON_INSTALL_DIR}
     )
 
     IF (USE_TESTS)


### PR DESCRIPTION
Added variable ALEMBIC_PYTHON_INSTALL_DIR that you can specify where it should install the python module. 

Useful when you don't want it to be placed under lib.