### PR TITLE
[cmake] Abilty to change where it installs the maya plug-ins from the cli

### DIFF
--- a/maya/AbcExport/CMakeLists.txt
+++ b/maya/AbcExport/CMakeLists.txt
@@ -80,4 +80,4 @@ set_target_properties(AbcExport PROPERTIES
     INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 
 INSTALL(TARGETS AbcExport
-        DESTINATION maya/plug-ins)
+        DESTINATION ${ALEMBIC_MAYA_PLUGINS_INSTALL_DIR})

--- a/maya/AbcImport/CMakeLists.txt
+++ b/maya/AbcImport/CMakeLists.txt
@@ -84,4 +84,4 @@ set_target_properties(AbcImport PROPERTIES
     INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 
 INSTALL(TARGETS AbcImport
-        DESTINATION maya/plug-ins)
+        DESTINATION ${ALEMBIC_MAYA_PLUGINS_INSTALL_DIR})

--- a/maya/CMakeLists.txt
+++ b/maya/CMakeLists.txt
@@ -36,6 +36,11 @@
 
 IF( ${MAYA_FOUND} )
 
+SET( ALEMBIC_MAYA_PLUGINS_INSTALL_DIR maya/plug-ins
+    CACHE PATH 
+    "Alembic's maya plug-ins install dir"
+)
+
 ADD_SUBDIRECTORY( AbcExport )
 ADD_SUBDIRECTORY( AbcImport )
 


### PR DESCRIPTION
Added variable ALEMBIC_MAYA_PLUGINS_INSTALL_DIR that you can specify where it should install the maya plug-ins.

Useful when you are building the plug-ins for multiple maya versions and package them up into one package.