### PR TITLE
AbcStitcher bug fix and add verbosity flag

### DIFF
--- a/bin/AbcStitcher/util.h
+++ b/bin/AbcStitcher/util.h
@@ -47,7 +47,7 @@ typedef std::vector< Alembic::Abc::ICompoundProperty > ICompoundPropertyVec;
 class TimeAndSamplesMap
 {
 public:
-    TimeAndSamplesMap() {};
+    TimeAndSamplesMap() {m_isVerbose = false;};
 
     void add(Alembic::AbcCoreAbstract::TimeSamplingPtr iTime,
              std::size_t iNumSamples);
@@ -56,9 +56,13 @@ public:
         Alembic::AbcCoreAbstract::TimeSamplingPtr iTime,
         std::size_t & oNumSamples) const;
 
+    void setVerbose(bool isVerbose){m_isVerbose = isVerbose;};
+    bool isVerbose() const {return m_isVerbose;};
+
 private:
     std::vector< Alembic::AbcCoreAbstract::TimeSamplingPtr > mTimeSampling;
     std::vector< std::size_t > mExpectedSamples;
+    bool m_isVerbose;
 };
 
 Alembic::AbcCoreAbstract::index_t


### PR DESCRIPTION
Add optional verbosity flag.

Try and accomodate stitching of cases that happen to use the same time
sampling but with slightly different start times in the same archive.

Fix bug with stitching hierarchies with no defined schema on intermediate
hierarchy.