### PR TITLE
Adsk contrib/maya api deprecation cleanup

### DIFF
--- a/maya/AbcExport/AbcExport.cpp
+++ b/maya/AbcExport/AbcExport.cpp
@@ -682,7 +682,7 @@ try
                     continue;
                 }
 
-                MPlug abcFilePlug = alembicNode.findPlug("abc_File");
+                MPlug abcFilePlug = alembicNode.findPlug("abc_File", true);
                 if (!abcFilePlug.isNull())
                 {
                     MFileObject alembicFile;
@@ -699,7 +699,7 @@ try
                     }
                 }
 
-                MPlug abcLayerFilePlug = alembicNode.findPlug("abc_layerFiles");
+                MPlug abcLayerFilePlug = alembicNode.findPlug("abc_layerFiles", true);
                 if (!abcLayerFilePlug.isNull())
                 {
                     MFnStringArrayData fnSAD( abcLayerFilePlug.asMObject() );

--- a/maya/AbcExport/AbcExport.cpp
+++ b/maya/AbcExport/AbcExport.cpp
@@ -666,7 +666,7 @@ try
 
             // check the path must exist before writing
             MFileObject absoluteFilePath;
-            absoluteFilePath.setRawFullName(absoluteFile.path());
+            absoluteFilePath.setRawFullName(absoluteFile.resolvedPath());
             if (!absoluteFilePath.exists()) {
                 MString error;
                 error.format("Path ^1s does not exist!", absoluteFilePath.resolvedFullName());

--- a/maya/AbcExport/AbcWriteJob.cpp
+++ b/maya/AbcExport/AbcWriteJob.cpp
@@ -267,7 +267,7 @@ MBoundingBox AbcWriteJob::getBoundingBox(double iFrame, const MMatrix & eMInvMat
             {
                 // check for riCurves flag for flattening all curve object to
                 // one curve group
-                MPlug riCurvesPlug = dagNode.findPlug("riCurves", &status);
+                MPlug riCurvesPlug = dagNode.findPlug("riCurves", true, &status);
                 if ( status == MS::kSuccess && riCurvesPlug.asBool() == true)
                 {
                     MBoundingBox box = dagNode.boundingBox();
@@ -389,7 +389,7 @@ void AbcWriteJob::setup(double iFrame, MayaTransformWriterPtr iParent, GetMember
 
     // look for riCurves flag for flattening all curve objects to a curve group
     MFnDependencyNode fnDepNode(ob, &status);
-    MPlug riCurvesPlug = fnDepNode.findPlug("riCurves", &status);
+    MPlug riCurvesPlug = fnDepNode.findPlug("riCurves", true, &status);
     bool riCurvesVal = riCurvesPlug.asBool();
     bool writeOutAsGroup = false;
     if (riCurvesVal)

--- a/maya/AbcExport/AttributesWriter.cpp
+++ b/maya/AbcExport/AttributesWriter.cpp
@@ -1735,7 +1735,7 @@ AttributesWriter::AttributesWriter(
 
         int sampType = util::getSampledType(plug);
 
-        MPlug scopePlug = iNode.findPlug(propName + cAttrScope);
+        MPlug scopePlug = iNode.findPlug(propName + cAttrScope, true);
         AbcGeom::GeometryScope scope = AbcGeom::kUnknownScope;
 
         if (!scopePlug.isNull())
@@ -1744,7 +1744,7 @@ AttributesWriter::AttributesWriter(
         }
 
         MString typeStr;
-        MPlug typePlug = iNode.findPlug(propName + cAttrType);
+        MPlug typePlug = iNode.findPlug(propName + cAttrType, true);
         if (!typePlug.isNull())
         {
             typeStr= typePlug.asString();

--- a/maya/AbcExport/MayaCameraWriter.cpp
+++ b/maya/AbcExport/MayaCameraWriter.cpp
@@ -76,16 +76,16 @@ MayaCameraWriter::MayaCameraWriter(MDagPath & iDag,
     {
         sel.getDependNode(0, renderObj);
         MFnDependencyNode dep(renderObj);
-        MPlug plug = dep.findPlug("motionBlurUseShutter");
+        MPlug plug = dep.findPlug("motionBlurUseShutter", true);
         if (plug.asBool())
         {
             MTime sec(1.0, MTime::kSeconds);
             double val = sec.as(MTime::uiUnit());
 
             mUseRenderShutter = true;
-            plug = dep.findPlug("motionBlurShutterOpen");
+            plug = dep.findPlug("motionBlurShutterOpen", true);
             mShutterOpen = plug.asDouble() / val;
-            plug = dep.findPlug("motionBlurShutterClose");
+            plug = dep.findPlug("motionBlurShutterClose", true);
             mShutterClose = plug.asDouble() / val;
         }
     }

--- a/maya/AbcExport/MayaLocatorWriter.cpp
+++ b/maya/AbcExport/MayaLocatorWriter.cpp
@@ -63,15 +63,15 @@ MayaLocatorWriter::MayaLocatorWriter(MDagPath & iDag,
     // of type double[6]
     Alembic::AbcCoreAbstract::DataType dType(Alembic::Util::kFloat64POD, 6);
 
-    MPlug posX = fnLocator.findPlug("localPositionX");
-    MPlug posY = fnLocator.findPlug("localPositionY");
-    MPlug posZ = fnLocator.findPlug("localPositionZ");
-    MPlug pos = fnLocator.findPlug("localPosition");
+    MPlug posX = fnLocator.findPlug("localPositionX", true);
+    MPlug posY = fnLocator.findPlug("localPositionY", true);
+    MPlug posZ = fnLocator.findPlug("localPositionZ", true);
+    MPlug pos = fnLocator.findPlug("localPosition", true);
 
-    MPlug scaleX = fnLocator.findPlug("localScaleX");
-    MPlug scaleY = fnLocator.findPlug("localScaleY");
-    MPlug scaleZ = fnLocator.findPlug("localScaleZ");
-    MPlug scale = fnLocator.findPlug("localScale");
+    MPlug scaleX = fnLocator.findPlug("localScaleX", true);
+    MPlug scaleY = fnLocator.findPlug("localScaleY", true);
+    MPlug scaleZ = fnLocator.findPlug("localScaleZ", true);
+    MPlug scale = fnLocator.findPlug("localScale", true);
 
     if ( iTimeIndex != 0 && (util::getSampledType(posX) != 0 ||
         util::getSampledType(posY) != 0 ||
@@ -135,12 +135,12 @@ void MayaLocatorWriter::write()
     }
 
     double val[6];
-    val[0] = fnLocator.findPlug("localPositionX").asDouble();
-    val[1] = fnLocator.findPlug("localPositionY").asDouble();
-    val[2] = fnLocator.findPlug("localPositionZ").asDouble();
-    val[3] = fnLocator.findPlug("localScaleX").asDouble();
-    val[4] = fnLocator.findPlug("localScaleY").asDouble();
-    val[5] = fnLocator.findPlug("localScaleZ").asDouble();
+    val[0] = fnLocator.findPlug("localPositionX", true).asDouble();
+    val[1] = fnLocator.findPlug("localPositionY", true).asDouble();
+    val[2] = fnLocator.findPlug("localPositionZ", true).asDouble();
+    val[3] = fnLocator.findPlug("localScaleX", true).asDouble();
+    val[4] = fnLocator.findPlug("localScaleY", true).asDouble();
+    val[5] = fnLocator.findPlug("localScaleZ", true).asDouble();
 
     mSp.set(val);
 }

--- a/maya/AbcExport/MayaMeshWriter.cpp
+++ b/maya/AbcExport/MayaMeshWriter.cpp
@@ -337,7 +337,7 @@ MayaMeshWriter::MayaMeshWriter(MDagPath & iDag,
     name = util::stripNamespaces(name, iArgs.stripNamespace);
 
     // check to see if this poly has been tagged as a SubD
-    MPlug plug = lMesh.findPlug("SubDivisionMesh");
+    MPlug plug = lMesh.findPlug("SubDivisionMesh", true);
 
     // if there is flag "autoSubd", and NO "SubDivisionMesh" was defined,
     // let's check whether the mesh has crease edge, crease vertex or holes
@@ -1029,15 +1029,15 @@ void MayaMeshWriter::writeSubD(
     samp.setFaceIndices(Alembic::Abc::Int32ArraySample(facePoints));
     samp.setFaceCounts(Alembic::Abc::Int32ArraySample(pointCounts));
 
-    MPlug plug = lMesh.findPlug("faceVaryingInterpolateBoundary");
+    MPlug plug = lMesh.findPlug("faceVaryingInterpolateBoundary", true);
     if (!plug.isNull())
         samp.setFaceVaryingInterpolateBoundary(plug.asInt());
 
-    plug = lMesh.findPlug("interpolateBoundary");
+    plug = lMesh.findPlug("interpolateBoundary", true);
     if (!plug.isNull())
         samp.setInterpolateBoundary(plug.asInt());
 
-    plug = lMesh.findPlug("faceVaryingPropagateCorners");
+    plug = lMesh.findPlug("faceVaryingPropagateCorners", true);
     if (!plug.isNull())
         samp.setFaceVaryingPropagateCorners(plug.asInt());
 

--- a/maya/AbcExport/MayaMeshWriter.cpp
+++ b/maya/AbcExport/MayaMeshWriter.cpp
@@ -158,7 +158,7 @@ getOutConnectedSG( const MDagPath &shapeDPath )
 
     // iterate through the output connected shading engines
     for( ; itDG.isDone()!= true; itDG.next() )
-        connSG.append( itDG.thisNode() );
+        connSG.append( itDG.currentItem() );
 
     return connSG;
 }

--- a/maya/AbcExport/MayaNurbsCurveWriter.cpp
+++ b/maya/AbcExport/MayaNurbsCurveWriter.cpp
@@ -196,7 +196,7 @@ void MayaNurbsCurveWriter::write()
     bool useConstWidth = false;
 
     MFnDependencyNode dep(mRootDagPath.transform());
-    MPlug constWidthPlug = dep.findPlug("width");
+    MPlug constWidthPlug = dep.findPlug("width", true);
 
     if (!constWidthPlug.isNull())
     {
@@ -321,7 +321,7 @@ void MayaNurbsCurveWriter::write()
         }
 
         // width
-        MPlug widthPlug = curve.findPlug("width");
+        MPlug widthPlug = curve.findPlug("width", true);
 
         if (!useConstWidth && !widthPlug.isNull())
         {

--- a/maya/AbcExport/MayaTransformWriter.cpp
+++ b/maya/AbcExport/MayaTransformWriter.cpp
@@ -45,7 +45,7 @@ void addTranslate(const MFnDependencyNode & iTrans,
 {
     Alembic::AbcGeom::XformOp op(Alembic::AbcGeom::kTranslateOperation, iHint);
 
-    MPlug xPlug = iTrans.findPlug(xName);
+    MPlug xPlug = iTrans.findPlug(xName, true);
     int xSamp = 0;
     if (!forceStatic)
     {
@@ -56,7 +56,7 @@ void addTranslate(const MFnDependencyNode & iTrans,
     }
     double xVal = xPlug.asDouble();
 
-    MPlug yPlug = iTrans.findPlug(yName);
+    MPlug yPlug = iTrans.findPlug(yName, true);
     int ySamp = 0;
     if (!forceStatic)
     {
@@ -67,7 +67,7 @@ void addTranslate(const MFnDependencyNode & iTrans,
     }
     double yVal = yPlug.asDouble();
 
-    MPlug zPlug = iTrans.findPlug(zName);
+    MPlug zPlug = iTrans.findPlug(zName, true);
     int zSamp = 0;
     if (!forceStatic)
     {
@@ -81,7 +81,7 @@ void addTranslate(const MFnDependencyNode & iTrans,
     // this is to handle the case where there is a connection to the parent
     // plug but not to the child plugs, if the connection is there then all
     // of the children are considered animated
-    MPlug parentPlug = iTrans.findPlug(parentName);
+    MPlug parentPlug = iTrans.findPlug(parentName, true);
     int parentSamp = 0;
     if (!forceStatic)
     {
@@ -172,7 +172,7 @@ void addRotate(const MFnDependencyNode & iTrans,
     // this is to handle the case where there is a connection to the parent
     // plug but not to the child plugs, if the connection is there then all
     // of the children are considered animated
-    MPlug parentPlug = iTrans.findPlug(parentName);
+    MPlug parentPlug = iTrans.findPlug(parentName, true);
     int parentSamp = 0;
     if (!forceStatic)
     {
@@ -190,7 +190,7 @@ void addRotate(const MFnDependencyNode & iTrans,
     for (; i > -1; i--)
     {
         unsigned int index = iOrder[i];
-        MPlug plug = iTrans.findPlug(iNames[index]);
+        MPlug plug = iTrans.findPlug(iNames[index], true);
         int samp = 0;
         if (!forceStatic)
         {
@@ -237,7 +237,7 @@ void addShear(const MFnDependencyNode & iTrans, bool forceStatic,
         Alembic::AbcGeom::kMayaShearHint);
 
     MString str = "shearXY";
-    MPlug xyPlug = iTrans.findPlug(str);
+    MPlug xyPlug = iTrans.findPlug(str, true);
     int xySamp = 0;
     if (!forceStatic)
     {
@@ -246,7 +246,7 @@ void addShear(const MFnDependencyNode & iTrans, bool forceStatic,
     double xyVal = xyPlug.asDouble();
 
     str = "shearXZ";
-    MPlug xzPlug = iTrans.findPlug(str);
+    MPlug xzPlug = iTrans.findPlug(str, true);
     int xzSamp = 0;
     if (!forceStatic)
     {
@@ -255,7 +255,7 @@ void addShear(const MFnDependencyNode & iTrans, bool forceStatic,
     double xzVal = xzPlug.asDouble();
 
     str = "shearYZ";
-    MPlug yzPlug = iTrans.findPlug(str);
+    MPlug yzPlug = iTrans.findPlug(str, true);
     int yzSamp = 0;
     if (!forceStatic)
     {
@@ -267,7 +267,7 @@ void addShear(const MFnDependencyNode & iTrans, bool forceStatic,
     // plug but not to the child plugs, if the connection is there then all
     // of the children are considered animated
     str = "shear";
-    MPlug parentPlug = iTrans.findPlug(str);
+    MPlug parentPlug = iTrans.findPlug(str, true);
     if (!forceStatic && util::getSampledType(parentPlug) != 0)
     {
         xySamp = 1;
@@ -331,7 +331,7 @@ void addScale(const MFnDependencyNode & iTrans,
     Alembic::AbcGeom::XformOp op(Alembic::AbcGeom::kScaleOperation,
         Alembic::AbcGeom::kScaleHint);
 
-    MPlug xPlug = iTrans.findPlug(xName);
+    MPlug xPlug = iTrans.findPlug(xName, true);
     int xSamp = 0;
     if (!forceStatic)
     {
@@ -342,7 +342,7 @@ void addScale(const MFnDependencyNode & iTrans,
     }
     double xVal = xPlug.asDouble();
 
-    MPlug yPlug = iTrans.findPlug(yName);
+    MPlug yPlug = iTrans.findPlug(yName, true);
     int ySamp = 0;
     if (!forceStatic)
     {
@@ -353,7 +353,7 @@ void addScale(const MFnDependencyNode & iTrans,
     }
     double yVal = yPlug.asDouble();
 
-    MPlug zPlug = iTrans.findPlug(zName);
+    MPlug zPlug = iTrans.findPlug(zName, true);
     int zSamp = 0;
     if (!forceStatic)
     {
@@ -367,7 +367,7 @@ void addScale(const MFnDependencyNode & iTrans,
     // this is to handle the case where there is a connection to the parent
     // plug but not to the child plugs, if the connection is there then all
     // of the children are considered animated
-    MPlug parentPlug = iTrans.findPlug(parentName);
+    MPlug parentPlug = iTrans.findPlug(parentName, true);
     int parentSamp = 0;
     if (!forceStatic)
     {
@@ -538,7 +538,7 @@ MayaTransformWriter::MayaTransformWriter(Alembic::AbcGeom::OObject & iParent,
 
             // need to look at inheritsTransform
             MFnDagNode dagNode(iDag);
-            MPlug inheritPlug = dagNode.findPlug("inheritsTransform");
+            MPlug inheritPlug = dagNode.findPlug("inheritsTransform", true);
             if (!inheritPlug.isNull())
             {
                 if (util::getSampledType(inheritPlug) != 0)
@@ -597,7 +597,7 @@ MayaTransformWriter::MayaTransformWriter(Alembic::AbcGeom::OObject & iParent,
 
             // need to look at inheritsTransform
             MFnDagNode dagNode(iDag);
-            MPlug inheritPlug = dagNode.findPlug("inheritsTransform");
+            MPlug inheritPlug = dagNode.findPlug("inheritsTransform", true);
             if (!inheritPlug.isNull())
             {
                 if (util::getSampledType(inheritPlug) != 0)
@@ -640,7 +640,7 @@ MayaTransformWriter::MayaTransformWriter(Alembic::AbcGeom::OObject & iParent,
 
         // inheritsTransform exists on both joints and transforms
         MFnDagNode dagNode(dag);
-        MPlug inheritPlug = dagNode.findPlug("inheritsTransform");
+        MPlug inheritPlug = dagNode.findPlug("inheritsTransform", true);
 
         // if inheritsTransform exists and is set to false, then we
         // don't need to worry about ancestor nodes above this one
@@ -686,7 +686,7 @@ MayaTransformWriter::MayaTransformWriter(Alembic::AbcGeom::OObject & iParent,
 
     // need to look at inheritsTransform
     MFnDagNode dagNode(iDag);
-    MPlug inheritPlug = dagNode.findPlug("inheritsTransform");
+    MPlug inheritPlug = dagNode.findPlug("inheritsTransform", true);
     if (!inheritPlug.isNull())
     {
         if (util::getSampledType(inheritPlug) != 0)
@@ -784,7 +784,7 @@ MayaTransformWriter::MayaTransformWriter(MayaTransformWriter & iParent,
 
     // need to look at inheritsTransform
     MFnDagNode dagNode(iDag);
-    MPlug inheritPlug = dagNode.findPlug("inheritsTransform");
+    MPlug inheritPlug = dagNode.findPlug("inheritsTransform", true);
     if (!inheritPlug.isNull())
     {
         if (util::getSampledType(inheritPlug) != 0)
@@ -985,7 +985,7 @@ void MayaTransformWriter::pushTransformStack(const MFnIkJoint & iJoint,
 
     // inspect the inverseParent scale
     // [IS] is ignored when Segment Scale Compensate is false
-    MPlug scaleCompensatePlug = iJoint.findPlug("segmentScaleCompensate");
+    MPlug scaleCompensatePlug = iJoint.findPlug("segmentScaleCompensate", true);
     if (scaleCompensatePlug.asBool())
     {
         addScale(iJoint, "inverseScale", "inverseScaleX", "inverseScaleY",

--- a/maya/AbcExport/MayaUtility.cpp
+++ b/maya/AbcExport/MayaUtility.cpp
@@ -284,7 +284,7 @@ bool util::isAnimated(MObject & object, bool checkParent)
     NodesToCheckStruct nodeStruct;
     for (; !iter.isDone(); iter.next())
     {
-        MObject node = iter.thisNode();
+        MObject node = iter.currentItem();
 
         if (node.hasFn(MFn::kPluginDependNode) ||
                 node.hasFn( MFn::kConstraint ) ||

--- a/maya/AbcExport/MayaUtility.cpp
+++ b/maya/AbcExport/MayaUtility.cpp
@@ -381,7 +381,7 @@ bool util::isDrivenBySplineIK(const MFnIkJoint & iJoint)
         if (!ikHandle.object().hasFn(MFn::kIkHandle)) continue;
 
         // find the ikSolver node.
-        MPlug ikSolverPlug = ikHandle.findPlug("ikSolver");
+        MPlug ikSolverPlug = ikHandle.findPlug("ikSolver", true);
         MPlugArray ikSolverDst;
         ikSolverPlug.connectedTo(ikSolverDst, true, false);
         for (unsigned int j = 0; j < ikSolverDst.length(); j++) {

--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -496,7 +496,7 @@ MStatus AlembicNode::compute(const MPlug & plug, MDataBlock & dataBlock)
 
         //Get list of input filenames
         MFnDependencyNode depNode(thisMObject());
-        MPlug layerFilesPlug = depNode.findPlug("abc_layerFiles");
+        MPlug layerFilesPlug = depNode.findPlug("abc_layerFiles", true);
         MFnStringArrayData fnSAD( layerFilesPlug.asMObject() );
         MStringArray storedFilenames = fnSAD.array();
 
@@ -579,7 +579,7 @@ MStatus AlembicNode::compute(const MPlug & plug, MDataBlock & dataBlock)
 
 
         MFnDependencyNode dep(thisMObject());
-        MPlug allSetsPlug = dep.findPlug("allColorSets");
+        MPlug allSetsPlug = dep.findPlug("allColorSets", true);
         CreateSceneVisitor visitor(inputTime, !allSetsPlug.isNull(),
             MObject::kNullObj, CreateSceneVisitor::NONE, "",
             mIncludeFilterString, mExcludeFilterString);

--- a/maya/AbcImport/CreateSceneHelper.cpp
+++ b/maya/AbcImport/CreateSceneHelper.cpp
@@ -207,8 +207,7 @@ namespace
                     MFnTypedAttribute attr;
                     MObject attrObj = attr.create(attrName, attrName,
                                               MFnData::kString, strAttrObject);
-                    fnDepNode.addAttribute(attrObj,
-                                         MFnDependencyNode::kLocalDynamicAttr);
+                    fnDepNode.addAttribute(attrObj);
                     abcFacesetNamePlug = fnDepNode.findPlug(attrObj, true);
                 }
                 abcFacesetNamePlug.setValue(faceSetName);
@@ -278,7 +277,7 @@ namespace
             Alembic::Util::int8_t visVal;
             iVisProp.get(&visVal);
             MFnDependencyNode dep(iParent);
-            MPlug plug = dep.findPlug("visibility");
+            MPlug plug = dep.findPlug("visibility", true);
             if (!plug.isNull())
             {
                 plug.setBool(visVal != 0);
@@ -332,9 +331,9 @@ namespace
         // Set the intermediate mesh as Maya intermediate object and
         // connect it to the inMesh plug
         modifier.renameNode(ioFn.object(), fn.name() + "Orig");
-        modifier.newPlugValueBool(ioFn.findPlug("intermediateObject"), true);
-        modifier.newPlugValueBool(ioFn.findPlug(aioAttr), true);
-        modifier.connect(ioFn.findPlug("outMesh"), fn.findPlug("inMesh"));
+        modifier.newPlugValueBool(ioFn.findPlug("intermediateObject", true), true);
+        modifier.newPlugValueBool(ioFn.findPlug(aioAttr, true), true);
+        modifier.connect(ioFn.findPlug("outMesh", true), fn.findPlug("inMesh", true));
         modifier.doIt();
     }
 
@@ -343,7 +342,7 @@ namespace
         // When merge with a referenced node with history, delete the
         // previous intermediate mesh that is created by Alembic plug-in.
         MPlugArray sources;
-        fn.findPlug("inMesh").connectedTo(sources, true, false);
+        fn.findPlug("inMesh", true).connectedTo(sources, true, false);
         if (sources.length() > 0)
         {
             MObject io = sources[0].node();
@@ -1013,7 +1012,7 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::ICurves & iNode)
 
         if (!fncurve.object().isNull())
         {
-            MPlug dstPlug = fncurve.findPlug("create");
+            MPlug dstPlug = fncurve.findPlug("create", true);
             disconnectAllPlugsTo(dstPlug);
             disconnectProps(fncurve, mData.mPropList, firstProp);
             addToPropList(firstProp, curvesObj);
@@ -1390,7 +1389,7 @@ MStatus CreateSceneVisitor::operator()(Alembic::AbcGeom::INuPatch& iNode)
             return status;
         }
 
-        MPlug dstPlug = fn.findPlug("create");
+        MPlug dstPlug = fn.findPlug("create", true);
         disconnectAllPlugsTo(dstPlug);
         disconnectProps(fn, mData.mPropList, firstProp);
         addToPropList(firstProp, nurbsObj);

--- a/maya/AbcImport/LocatorHelper.cpp
+++ b/maya/AbcImport/LocatorHelper.cpp
@@ -77,17 +77,17 @@ MObject create(Alembic::AbcGeom::IXform & iLocator,
 
         // set the plugs and be done
         MPlug dstPlug;
-        dstPlug = fnLocator.findPlug("localPositionX");
+        dstPlug = fnLocator.findPlug("localPositionX", true);
         dstPlug.setValue(oSample[0]);
-        dstPlug = fnLocator.findPlug("localPositionY");
+        dstPlug = fnLocator.findPlug("localPositionY", true);
         dstPlug.setValue(oSample[1]);
-        dstPlug = fnLocator.findPlug("localPositionZ");
+        dstPlug = fnLocator.findPlug("localPositionZ", true);
         dstPlug.setValue(oSample[2]);
-        dstPlug = fnLocator.findPlug("localScaleX");
+        dstPlug = fnLocator.findPlug("localScaleX", true);
         dstPlug.setValue(oSample[3]);
-        dstPlug = fnLocator.findPlug("localScaleY");
+        dstPlug = fnLocator.findPlug("localScaleY", true);
         dstPlug.setValue(oSample[4]);
-        dstPlug = fnLocator.findPlug("localScaleZ");
+        dstPlug = fnLocator.findPlug("localScaleZ", true);
         dstPlug.setValue(oSample[5]);
     }
 

--- a/maya/AbcImport/MeshHelper.cpp
+++ b/maya/AbcImport/MeshHelper.cpp
@@ -76,7 +76,7 @@ namespace
     // the new swap position could get messed up
     void clearPt(MFnMesh & ioMesh)
     {
-        MPlug ptPlug = ioMesh.findPlug("pt");
+        MPlug ptPlug = ioMesh.findPlug("pt", true);
         unsigned int numElements = ptPlug.numElements();
         if (ptPlug.isArray() && (numElements > 0))
         {
@@ -1030,7 +1030,7 @@ void disconnectMesh(MObject & iMeshObject,
 
     // disconnect old connection from AlembicNode or some other nodes
     // to inMesh if one such connection exist
-    MPlug dstPlug = fnMesh.findPlug("inMesh");
+    MPlug dstPlug = fnMesh.findPlug("inMesh", true);
     disconnectAllPlugsTo(dstPlug);
 
     disconnectProps(fnMesh, iSampledPropList, iFirstProp);
@@ -1102,7 +1102,7 @@ MObject createPoly(double iFrame, PolyMeshAndFriends & iNode, MObject & iParent)
         MFnNumericData::kBoolean, true);
         attr.setKeyable(true);
         attr.setHidden(false);
-        fnMesh.addAttribute(attrObj, MFnDependencyNode::kLocalDynamicAttr);
+        fnMesh.addAttribute(attrObj);
     }
 
     return obj;
@@ -1145,7 +1145,7 @@ MObject createSubD(double iFrame, SubDAndFriends & iNode, MObject & iParent)
         MFnNumericData::kBoolean, 1);
     numAttr.setKeyable(true);
     numAttr.setHidden(false);
-    fnMesh.addAttribute(attrObj, MFnDependencyNode::kLocalDynamicAttr);
+    fnMesh.addAttribute(attrObj);
 
     if (samp.getInterpolateBoundary() > 0)
     {
@@ -1155,7 +1155,7 @@ MObject createSubD(double iFrame, SubDAndFriends & iNode, MObject & iParent)
 
         numAttr.setKeyable(true);
         numAttr.setHidden(false);
-        fnMesh.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+        fnMesh.addAttribute(attrObj);
     }
 
     if (samp.getFaceVaryingInterpolateBoundary() > 0)
@@ -1166,7 +1166,7 @@ MObject createSubD(double iFrame, SubDAndFriends & iNode, MObject & iParent)
 
         numAttr.setKeyable(true);
         numAttr.setHidden(false);
-        fnMesh.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+        fnMesh.addAttribute(attrObj);
     }
 
     if (samp.getFaceVaryingPropagateCorners() > 0)
@@ -1177,7 +1177,7 @@ MObject createSubD(double iFrame, SubDAndFriends & iNode, MObject & iParent)
 
         numAttr.setKeyable(true);
         numAttr.setHidden(false);
-        fnMesh.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+        fnMesh.addAttribute(attrObj);
     }
 
     fillCreasesCornersAndHoles(fnMesh, iNode, samp);

--- a/maya/AbcImport/NodeIteratorVisitorHelper.cpp
+++ b/maya/AbcImport/NodeIteratorVisitorHelper.cpp
@@ -97,11 +97,11 @@ void addString(MObject & iParent, const std::string & iAttrName,
     MObject attrObj = attr.create(attrName, attrName, MFnData::kString,
         strAttrObject);
     MFnDependencyNode parentFn(iParent);
-    parentFn.addAttribute(attrObj, MFnDependencyNode::kLocalDynamicAttr);
+    parentFn.addAttribute(attrObj);
 
     // work around bug where this string wasn't getting saved to a file when
     // it is the default value
-    MPlug plug = parentFn.findPlug(attrName);
+    MPlug plug = parentFn.findPlug(attrName, true);
     if (!plug.isNull())
     {
         plug.setString(attrValue);
@@ -161,7 +161,7 @@ bool addArrayProp(Alembic::Abc::IArrayProperty & iProp, MObject & iParent)
 {
     MFnDependencyNode parentFn(iParent);
     MString attrName(iProp.getName().c_str());
-    MPlug plug = parentFn.findPlug(attrName);
+    MPlug plug = parentFn.findPlug(attrName, true);
 
     MFnTypedAttribute typedAttr;
     MFnNumericAttribute numAttr;
@@ -866,10 +866,9 @@ bool addArrayProp(Alembic::Abc::IArrayProperty & iProp, MObject & iParent)
                 attrObj = typedAttr.create(attrName, attrName, MFnData::kString,
                         MObject::kNullObj);
 
-                parentFn.addAttribute(attrObj,
-                    MFnDependencyNode::kLocalDynamicAttr);
+                parentFn.addAttribute(attrObj);
 
-                plug = parentFn.findPlug(attrName);
+                plug = parentFn.findPlug(attrName, true);
                 if (!plug.isNull())
                 {
                     plug.setValue(strAttrObject);
@@ -952,9 +951,9 @@ bool addArrayProp(Alembic::Abc::IArrayProperty & iProp, MObject & iParent)
                 attrObj = typedAttr.create(attrName, attrName, MFnData::kString,
                         MObject::kNullObj);
 
-                parentFn.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+                parentFn.addAttribute(attrObj);
 
-                plug = parentFn.findPlug(attrName);
+                plug = parentFn.findPlug(attrName, true);
                 if (!plug.isNull())
                 {
                     plug.setValue(strAttrObject);
@@ -983,7 +982,7 @@ bool addArrayProp(Alembic::Abc::IArrayProperty & iProp, MObject & iParent)
 
     if ( ! parentFn.hasAttribute( attrName ) )
     {
-        parentFn.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+        parentFn.addAttribute(attrObj);
     }
 
     addArbAttrAndScope(iParent, iProp.getName(),
@@ -1159,7 +1158,7 @@ bool addScalarProp(Alembic::Abc::IScalarProperty & iProp, MObject & iParent)
 {
     MFnDependencyNode parentFn(iParent);
     MString attrName(iProp.getName().c_str());
-    MPlug plug = parentFn.findPlug(attrName);
+    MPlug plug = parentFn.findPlug(attrName, true);
 
     MFnTypedAttribute typedAttr;
     MFnNumericAttribute numAttr;
@@ -1294,9 +1293,9 @@ bool addScalarProp(Alembic::Abc::IScalarProperty & iProp, MObject & iParent)
           attrObj = typedAttr.create(attrName, attrName, MFnData::kString,
                         MObject::kNullObj);
 
-          parentFn.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+          parentFn.addAttribute(attrObj);
 
-          plug = parentFn.findPlug(attrName);
+          plug = parentFn.findPlug(attrName, true);
           if (!plug.isNull())
           {
              plug.setValue(strAttrObject);
@@ -1321,7 +1320,7 @@ bool addScalarProp(Alembic::Abc::IScalarProperty & iProp, MObject & iParent)
 
     if ( ! parentFn.hasAttribute( attrName ) )
     {
-        parentFn.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+        parentFn.addAttribute(attrObj);
     }
 
     addArbAttrAndScope(iParent, iProp.getName(),
@@ -2942,15 +2941,14 @@ MString connectAttr(ArgData & iArgData)
         MFnNumericAttribute numAttr;
         MObject attrObj = numAttr.create("allColorSets", "allColorSets",
             MFnNumericData::kBoolean);
-        alembicNodeFn.addAttribute(attrObj,
-            MFnDependencyNode::kLocalDynamicAttr);
+        alembicNodeFn.addAttribute(attrObj);
     }
 
     // set AlembicNode name
     MString fileName;
     stripFileName((*iArgData.mFileNames.begin()).c_str(), fileName);
     MString alembicNodeName = fileName +"_AlembicNode";
-    alembicNodeFn.setName(alembicNodeName, &status);
+    alembicNodeFn.setName(alembicNodeName, false, &status);
 
     // set input file name (Deprecated but leaving here for legacy support)
     MPlug plug = alembicNodeFn.findPlug("abc_File", true, &status);

--- a/maya/AbcImport/NurbsCurveHelper.cpp
+++ b/maya/AbcImport/NurbsCurveHelper.cpp
@@ -260,8 +260,7 @@ MObject createCurves(const std::string & iName,
         MFnNumericAttribute attr;
         MObject attrObj = attr.create("riCurves", "riCurves",
             MFnNumericData::kBoolean, 1);
-        fnTrans.addAttribute(attrObj,
-            MFnDependencyNode::kLocalDynamicAttr);
+        fnTrans.addAttribute(attrObj);
 
         // constant width
         if (widths && widths->size() == 1)
@@ -269,9 +268,8 @@ MObject createCurves(const std::string & iName,
             MFnNumericAttribute widthAttr;
             attrObj = widthAttr.create("width", "width",
                 MFnNumericData::kFloat, (*widths)[0]);
-            fnTrans.addAttribute(attrObj,
-                MFnDependencyNode::kLocalDynamicAttr);
-            fnTrans.findPlug("width").setValue((*widths)[0]);
+            fnTrans.addAttribute(attrObj);
+            fnTrans.findPlug("width", true).setValue((*widths)[0]);
         }
     }
 
@@ -389,9 +387,8 @@ MObject createCurves(const std::string & iName,
             MFnNumericAttribute widthAttr;
             MObject attrObj = widthAttr.create("width",
                 "width", MFnNumericData::kFloat, (*widths)[0]);
-            curve.addAttribute(attrObj,
-                MFnDependencyNode::kLocalDynamicAttr);
-            curve.findPlug("width").setValue((*widths)[0]);
+            curve.addAttribute(attrObj);
+            curve.findPlug("width", true).setValue((*widths)[0]);
         }
         // per vertex width
         else if (widths && widths->size() >= curVert && numVerts > 0 &&
@@ -405,8 +402,7 @@ MObject createCurves(const std::string & iName,
             MObject attrObj = attr.create("width", "width");
             attr.addDataAccept(MFnData::kDoubleArray);
             MFnDependencyNode mParentFn(curve.object());
-            mParentFn.addAttribute(attrObj,
-                MFnDependencyNode::kLocalDynamicAttr);
+            mParentFn.addAttribute(attrObj);
 
             MPlug plug(curveObj, attrObj);
             plug.setValue(attrObject);

--- a/maya/AbcImport/XformHelper.cpp
+++ b/maya/AbcImport/XformHelper.cpp
@@ -431,52 +431,52 @@ MStatus connectToXform(const Alembic::AbcGeom::XformSample & iSamp,
 
     MPlug dstPlug;
 
-    dstPlug = trans.findPlug("scalePivotX");
+    dstPlug = trans.findPlug("scalePivotX", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("scalePivotY");
+    dstPlug = trans.findPlug("scalePivotY", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("scalePivotZ");
+    dstPlug = trans.findPlug("scalePivotZ", true);
     disconnectAllPlugsTo(dstPlug);
     trans.setScalePivot(point, gSpace, gBalance);
 
-    dstPlug = trans.findPlug("scaleX");
+    dstPlug = trans.findPlug("scaleX", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("scaleY");
+    dstPlug = trans.findPlug("scaleY", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("scaleZ");
+    dstPlug = trans.findPlug("scaleZ", true);
     disconnectAllPlugsTo(dstPlug);
     const double scale[3] = {1, 1, 1};
     trans.setScale(scale);
 
-    dstPlug = trans.findPlug("shearXY");
+    dstPlug = trans.findPlug("shearXY", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("shearXZ");
+    dstPlug = trans.findPlug("shearXZ", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("shearYZ");
+    dstPlug = trans.findPlug("shearYZ", true);
     disconnectAllPlugsTo(dstPlug);
     trans.setShear(zero);
 
-    dstPlug = trans.findPlug("scalePivotTranslateX");
+    dstPlug = trans.findPlug("scalePivotTranslateX", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("scalePivotTranslateY");
+    dstPlug = trans.findPlug("scalePivotTranslateY", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("scalePivotTranslateZ");
+    dstPlug = trans.findPlug("scalePivotTranslateZ", true);
     disconnectAllPlugsTo(dstPlug);
     trans.setScalePivotTranslation(vec, gSpace);
 
-    dstPlug = trans.findPlug("rotatePivotX");
+    dstPlug = trans.findPlug("rotatePivotX", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("rotatePivotY");
+    dstPlug = trans.findPlug("rotatePivotY", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("rotatePivotZ");
+    dstPlug = trans.findPlug("rotatePivotZ", true);
     disconnectAllPlugsTo(dstPlug);
     trans.setRotatePivot(point, gSpace, gBalance);
 
-    dstPlug = trans.findPlug("rotateAxisX");
+    dstPlug = trans.findPlug("rotateAxisX", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("rotateAxisY");
+    dstPlug = trans.findPlug("rotateAxisY", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("rotateAxisZ");
+    dstPlug = trans.findPlug("rotateAxisZ", true);
     disconnectAllPlugsTo(dstPlug);
     const MQuaternion quat;
     trans.setRotateOrientation(quat, gSpace, gBalance);
@@ -484,36 +484,36 @@ MStatus connectToXform(const Alembic::AbcGeom::XformSample & iSamp,
     MTransformationMatrix::RotationOrder order =
         MTransformationMatrix::kXYZ;
 
-    dstPlug = trans.findPlug("rotateOrder");
+    dstPlug = trans.findPlug("rotateOrder", true);
     disconnectAllPlugsTo(dstPlug);
     bool reorder = true;
     trans.setRotationOrder(order, reorder);
 
-    dstPlug = trans.findPlug("rotateX");
+    dstPlug = trans.findPlug("rotateX", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("rotateY");
+    dstPlug = trans.findPlug("rotateY", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("rotateZ");
+    dstPlug = trans.findPlug("rotateZ", true);
     disconnectAllPlugsTo(dstPlug);
     trans.setRotation(zero, order);
 
-    dstPlug = trans.findPlug("rotatePivotTranslateX");
+    dstPlug = trans.findPlug("rotatePivotTranslateX", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("rotatePivotTranslateY");
+    dstPlug = trans.findPlug("rotatePivotTranslateY", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("rotatePivotTranslateZ");
+    dstPlug = trans.findPlug("rotatePivotTranslateZ", true);
     disconnectAllPlugsTo(dstPlug);
     trans.setRotatePivotTranslation(vec, gSpace);
 
-    dstPlug = trans.findPlug("translateX");
+    dstPlug = trans.findPlug("translateX", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("translateY");
+    dstPlug = trans.findPlug("translateY", true);
     disconnectAllPlugsTo(dstPlug);
-    dstPlug = trans.findPlug("translateZ");
+    dstPlug = trans.findPlug("translateZ", true);
     disconnectAllPlugsTo(dstPlug);
     trans.setTranslation(vec, gSpace);
 
-    dstPlug = trans.findPlug("inheritsTransform");
+    dstPlug = trans.findPlug("inheritsTransform", true);
     disconnectAllPlugsTo(dstPlug);
     dstPlug.setBool(iSamp.getInheritsXforms());
 

--- a/maya/AbcImport/util.cpp
+++ b/maya/AbcImport/util.cpp
@@ -179,11 +179,11 @@ void disconnectProps(MFnDependencyNode & iNode,
         MPlug dstPlug;
         if (propName == Alembic::AbcGeom::kVisibilityPropertyName)
         {
-            dstPlug = iNode.findPlug("visibility");
+            dstPlug = iNode.findPlug("visibility", true);
         }
         else
         {
-            dstPlug = iNode.findPlug(propName.c_str());
+            dstPlug = iNode.findPlug(propName.c_str(), true);
         }
 
         // make sure the long name matches
@@ -344,7 +344,7 @@ MStatus getPlugByName(const MString & objName, const MString & attrName,
     {
         MFnDependencyNode mFn(object, &status);
         if (status == MS::kSuccess)
-            plug = mFn.findPlug(attrName, &status);
+            plug = mFn.findPlug(attrName, true, &status);
     }
 
     return status;

--- a/maya/AbcImport/util.cpp
+++ b/maya/AbcImport/util.cpp
@@ -97,7 +97,7 @@ MObjectArray getOutConnectedSG( const MDagPath &shapeDPath )
 
     // iterate through the output connected shading engines
     for( ; itDG.isDone()!= true; itDG.next() )
-        connSG.append( itDG.thisNode() );
+        connSG.append( itDG.currentItem() );
 
     return connSG;
 }


### PR DESCRIPTION
These commits removes the use of the deprecated Maya API methods in the AbcImport and AbcExport plugins