### PR TITLE
Alembic file translator should resolve in the same way as AbcImport command

### DIFF
--- a/maya/AbcImport/AlembicImportFileTranslator.cpp
+++ b/maya/AbcImport/AlembicImportFileTranslator.cpp
@@ -43,8 +43,10 @@ MStatus AlembicImportFileTranslator::reader(
                                         const MString& optionsString,
                                         MPxFileTranslator::FileAccessMode mode)
 {
+    MFileObject fileResolver(file);
+    fileResolver.setResolveMethod(MFileObject::kInputFile);
     MString script;
-    script.format ("AbcImport \"^1s\";", file.resolvedFullName());
+    script.format ("AbcImport \"^1s\";", fileResolver.resolvedFullName());
 
     MStatus status = MGlobal::executeCommand (script);
 
@@ -56,7 +58,10 @@ AlembicImportFileTranslator::identifyFile(const MFileObject& file,
                                           const char* buffer,
                                           short size) const
 {
-    MString name = file.resolvedName();
+    MFileObject fileResolver(file);
+    fileResolver.setResolveMethod(MFileObject::kInputFile);
+
+    MString name = fileResolver.resolvedName();
     unsigned int len = name.numChars();
     if (len > 4 && name.substringW(len - 4, len - 1).toLowerCase() == ".abc")
     {


### PR DESCRIPTION

Alembic should resolve file path by using kInputFile for relative and
dirmapping. This was done for AbcImport command. The file translator
should do the same. This affects File -> Import and File -> Reference.

The issue is Maya can't resolve C:/path/ball.abc as an absolute path
in kNone mode. On Linux, C:/path/ball.abc is a relative path. Python
os.path.isabs() is the same. So we have to treat C:/path/ball.abc
as a relative path and prepend the current workspace path to it:
/path/to/workspace/C:/path/ball.abc. This is a bad path.. The
behavior is not wrong. We can't say C:/path/ball.abc is an absolute
path on Linux..