### PR TITLE
Partially revert "Misc Cleanup"

### DIFF
--- a/maya/AbcExport/AbcExport.cpp
+++ b/maya/AbcExport/AbcExport.cpp
@@ -36,6 +36,7 @@
 
 #include "AbcExport.h"
 #include "AbcWriteJob.h"
+#include "Export.h"
 #include "MayaUtility.h"
 
 #include <maya/MFnPlugin.h>
@@ -1145,7 +1146,7 @@ catch (std::exception & e)
 
 
 
-MStatus initializePlugin(MObject obj)
+ALEMBIC_MAYA_PLUGIN_EXPORT  MStatus initializePlugin(MObject obj)
 {
     MStatus status;
     MFnPlugin plugin(obj, "Alembic", ABCEXPORT_VERSION, "Any");
@@ -1168,7 +1169,7 @@ MStatus initializePlugin(MObject obj)
     return status;
 }
 
-MStatus uninitializePlugin(MObject obj)
+ALEMBIC_MAYA_PLUGIN_EXPORT MStatus uninitializePlugin(MObject obj)
 {
     MStatus status;
     MFnPlugin plugin(obj);

--- a/maya/AbcImport/main.cpp
+++ b/maya/AbcImport/main.cpp
@@ -37,6 +37,7 @@
 #include "AlembicNode.h"
 #include "AbcImport.h"
 #include "AlembicImportFileTranslator.h"
+#include "Export.h"
 
 #include <maya/MGlobal.h>
 #include <maya/MFnPlugin.h>
@@ -46,7 +47,7 @@
 // Interesting trivia: 0x2697 is the unicode character for Alembic
 const MTypeId AlembicNode::mMayaNodeId(0x00082697);
 
-MStatus initializePlugin(MObject obj)
+ALEMBIC_MAYA_PLUGIN_EXPORT MStatus initializePlugin(MObject obj)
 {
     const char * pluginVersion = "1.0";
     MFnPlugin plugin(obj, "Alembic", pluginVersion, "Any");
@@ -90,7 +91,7 @@ MStatus initializePlugin(MObject obj)
     return status;
 }
 
-MStatus uninitializePlugin(MObject obj)
+ALEMBIC_MAYA_PLUGIN_EXPORT  MStatus uninitializePlugin(MObject obj)
 {
     MFnPlugin plugin(obj);
 

--- a/maya/Export.h
+++ b/maya/Export.h
@@ -1,0 +1,47 @@
+//-*****************************************************************************
+//
+// Copyright (c) 2009-2016,
+//  Sony Pictures Imageworks, Inc. and
+//  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Sony Pictures Imageworks, nor
+// Industrial Light & Magic nor the names of their contributors may be used
+// to endorse or promote products derived from this software without specific
+// prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//-*****************************************************************************
+
+#ifndef _Alembic_Maya_Export_h_
+#define _Alembic_Maya_Export_h_
+
+#if defined _WIN32 || defined _WIN64
+    #define ALEMBIC_MAYA_PLUGIN_EXPORT __declspec(dllexport)
+#else
+    #define ALEMBIC_MAYA_PLUGIN_EXPORT __attribute__ ((visibility ("default")))
+#endif
+
+#endif /* _Alembic_Maya_Export_h_ */
+


### PR DESCRIPTION
This partially reverts commit aa8dd6794163c5043b90b75e9e7d9cdff1891516.

Brings back the ALEMBIC_MAYA_PLUGIN_EXPORT.

Removing the export definitions works in Maya 2018 or greater because
the initializePlugin and uninitializePlugin functions are delcared with
proper export definitions in MFnPlugin.h