### PR TITLE
AbcStitcher: fix crash when Subd corner parameters were set in input files

### DIFF
--- a/bin/AbcStitcher/AbcStitcher.cpp
+++ b/bin/AbcStitcher/AbcStitcher.cpp
@@ -451,7 +451,7 @@ void visitObjects(std::vector< IObject > & iObjects, OObject & oParentObj,
 
                 Abc::FloatArraySamplePtr cornerSpPtr = iSamp.getCornerSharpnesses();
                 if (cornerSpPtr)
-                    oSamp.setCreaseSharpnesses(*cornerSpPtr);
+                    oSamp.setCornerSharpnesses(*cornerSpPtr);
 
                 Abc::Int32ArraySamplePtr holePtr = iSamp.getHoles();
                 if (holePtr)


### PR DESCRIPTION
cornerSharpnesses would be written to creaseSharpnesses and cornerSharpnesses would not be written at all, causing crashes when corner parameters were set in input files. Also, I'm with Tippett Studio and we have signed a CLA.  