### PR TITLE
Address instancing issue in 171.

### DIFF
--- a/lib/Alembic/Abc/ISchemaObject.h
+++ b/lib/Alembic/Abc/ISchemaObject.h
@@ -159,8 +159,11 @@ public:
     ISchemaObject( const IObject & iObject,
                    const Argument &iArg0 = Argument(),
                    const Argument &iArg1 = Argument() )
-    : IObject( iObject.getPtr(), GetErrorHandlerPolicy( iObject, iArg0, iArg1 ) )
+    : IObject( iObject )
     {
+        getErrorHandler().setPolicy(
+            GetErrorHandlerPolicy( iObject, iArg0, iArg1 ) );
+
         ALEMBIC_ABC_SAFE_CALL_BEGIN(
             "ISchemaObject::ISchemaObject( wrap )" );
 
@@ -186,8 +189,11 @@ public:
                    WrapExistingFlag iFlag,
                    const Argument &iArg0 = Argument(),
                    const Argument &iArg1 = Argument() )
-    : IObject( iObject.getPtr(), GetErrorHandlerPolicy( iObject, iArg0, iArg1 ) )
+    : IObject( iObject )
     {
+        getErrorHandler().setPolicy(
+            GetErrorHandlerPolicy( iObject, iArg0, iArg1 ) );
+
         ALEMBIC_ABC_SAFE_CALL_BEGIN(
             "ISchemaObject::ISchemaObject( wrapflag )" );
 

--- a/lib/Alembic/Abc/Tests/CompileTest.cpp
+++ b/lib/Alembic/Abc/Tests/CompileTest.cpp
@@ -170,6 +170,38 @@ void testITypedArrayProperty( IObject &iObject )
     boolProp.get( bPtr );
 }
 
+void testInstancedSchema()
+{
+    {
+        OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(),
+                          "instancedTest.abc" );
+
+        OObject archiveTop = archive.getTop();
+        OObject a( archiveTop, "a" );
+        OTest aa( a, "a" );
+
+        OObject b( archiveTop, "b" );
+        b.addChildInstance( aa, "bb" );
+    }
+
+    {
+        IArchive archive( Alembic::AbcCoreOgawa::ReadArchive(),
+                          "instancedTest.abc" );
+        IObject archiveTop = archive.getTop();
+        IObject b( archiveTop, "b" );
+        IObject bb( b, "bb" );
+        ITest bb1( b, "bb" );
+        ITest bb2( bb );
+        ABCA_ASSERT( bb.getName() == bb1.getName(),
+            "Instanced bb and bb1 names don't match." );
+        ABCA_ASSERT( bb.getName() == bb2.getName(),
+            "Instanced bb and bb1 names don't match." );
+        ABCA_ASSERT( bb.getFullName() == "/b/bb", "Bad full name for bb" );
+        ABCA_ASSERT( bb1.getFullName() == "/b/bb", "Bad full name for bb1" );
+        ABCA_ASSERT( bb2.getFullName() == "/b/bb", "Bad full name for bb2" );
+    }
+}
+
 int main( int argc, char *argv[] )
 {
 
@@ -217,5 +249,7 @@ int main( int argc, char *argv[] )
         testITypedScalarProperty( child );
         testITypedArrayProperty( child );
     }
+
+    testInstancedSchema();
     return 0;
 }

--- a/lib/Alembic/Abc/Tests/InstanceTest.cpp
+++ b/lib/Alembic/Abc/Tests/InstanceTest.cpp
@@ -193,6 +193,10 @@ void simpleTestIn( const std::string& iArchiveName )
     TESTING_ASSERT( x5.isInstanceDescendant() );
     TESTING_ASSERT( x5.isInstanceRoot() );
     TESTING_ASSERT( x5.instanceSourcePath() == x4.getFullName() );
+    TESTING_ASSERT( x5.getName() == "x5" );
+
+    IObject x5Copy = x5;
+    TESTING_ASSERT( x5Copy.getName() == "x5" );
 
     numChildren = x5.getNumChildren();
     TESTING_ASSERT( numChildren == 2 );


### PR DESCRIPTION
When "wrapping" an IObject around it's ISchemaObject, make sure we copy the
full IObject so the instancing info is properly copied over as well.