### PR TITLE
Address issue 188  involving userProperties and geomParams.

### DIFF
--- a/lib/Alembic/Abc/OCompoundProperty.cpp
+++ b/lib/Alembic/Abc/OCompoundProperty.cpp
@@ -214,7 +214,13 @@ void OCompoundProperty::init( AbcA::CompoundPropertyWriterPtr iParent,
 
     getErrorHandler().setPolicy( args.getErrorHandlerPolicy() );
 
-    m_property = iParent->createCompoundProperty( iName, args.getMetaData() );
+    m_property = Alembic::Util::dynamic_pointer_cast<
+        AbcA::CompoundPropertyWriter>( iParent->getProperty( iName ) );
+    if ( !m_property )
+    {
+        m_property = iParent->createCompoundProperty( iName,
+                                                      args.getMetaData() );
+    }
 
     ALEMBIC_ABC_SAFE_CALL_END_RESET();
 }

--- a/lib/Alembic/AbcGeom/Tests/XformTests.cpp
+++ b/lib/Alembic/AbcGeom/Tests/XformTests.cpp
@@ -620,6 +620,26 @@ void sparseTest2()
 }
 
 //-*****************************************************************************
+void issue188()
+{
+    std::string name = "issue188.abc";
+
+    OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), name);
+    OXform axform( OObject( archive ),  "a" );
+
+    Alembic::AbcGeom::OXformSchema schema0, schema1;
+    schema0 = axform.getSchema();
+    schema1 = schema0;
+
+    Alembic::Abc::OCompoundProperty user0 = schema0.getUserProperties();
+    Alembic::Abc::OCompoundProperty user1 = schema1.getUserProperties();
+
+    Alembic::Abc::OBox3dProperty boxy( user0, "boxy" );
+    TESTING_ASSERT( user0.getNumProperties() == 1 );
+    TESTING_ASSERT( user1.getNumProperties() == 1 );
+}
+
+//-*****************************************************************************
 int main( int argc, char *argv[] )
 {
     xformOut();
@@ -628,5 +648,6 @@ int main( int argc, char *argv[] )
     xformTreeCreate();
     sparseTest();
     sparseTest2();
+    issue188();
     return 0;
 }


### PR DESCRIPTION
When creating a CompoundProperty, see if it was already created and if so attempt to reuse it.