### PR TITLE
Find custom python

### DIFF
--- a/cmake/AlembicPython.cmake
+++ b/cmake/AlembicPython.cmake
@@ -33,8 +33,8 @@
 ##
 ##-*****************************************************************************
 
-FIND_PACKAGE ( PythonLibs 2 REQUIRED )
 FIND_PACKAGE ( PythonInterp 2 REQUIRED )
+FIND_PACKAGE ( PythonLibs 2 REQUIRED )
 IF(PYTHONLIBS_FOUND)
     SET(ALEMBIC_PYTHON_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
     SET(ALEMBIC_PYTHON_LIBRARY ${PYTHON_LIBRARIES})

--- a/cmake/Modules/FindPyIlmBase.cmake
+++ b/cmake/Modules/FindPyIlmBase.cmake
@@ -119,6 +119,7 @@ ELSE()
         PATHS
         ${LIBRARY_PATHS}
         /usr/local/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages
+        ${ALEMBIC_PYILMBASE_ROOT}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages
         ${ALEMBIC_PYILMBASE_ROOT}/lib64/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages
         DOC "The imathmodule.so module directory"
     )


### PR DESCRIPTION
This PR allow to build Alembic against a custom Python installation by first finding a `PythonInterp` pointed by the `PATH` environment variable before `PythonLibs`.

See https://cmake.org/cmake/help/v2.8.11/cmake.html#module:FindPythonInterp

It also allows to find PyIlmBase in a custom `/lib` path, not just `/lib64`.
