### PR TITLE
Subd and abc export acyclic fix

### DIFF
--- a/lib/Alembic/AbcGeom/OSubD.h
+++ b/lib/Alembic/AbcGeom/OSubD.h
@@ -248,8 +248,10 @@ public:
             if( !m_positions.getData() && !m_faceIndices.getData() && !m_faceCounts.getData() )
             {
                 if( m_uvs.getVals() || m_velocities.getData() ||
-                    (m_faceVaryingInterpolateBoundary != 0) || (m_faceVaryingPropagateCorners != 0) ||
-                    (m_interpolateBoundary != 0) || m_creaseIndices.getData() ||
+                    (m_faceVaryingInterpolateBoundary != ABC_GEOM_SUBD_NULL_INT_VALUE) ||
+                    (m_faceVaryingPropagateCorners != ABC_GEOM_SUBD_NULL_INT_VALUE) ||
+                    (m_interpolateBoundary != ABC_GEOM_SUBD_NULL_INT_VALUE) ||
+                    m_creaseIndices.getData() ||
                     m_creaseLengths.getData() || m_creaseSharpnesses.getData() ||
                     m_cornerIndices.getData() || m_cornerSharpnesses.getData() ||
                     m_holes.getData() )

--- a/lib/Alembic/AbcGeom/Tests/SubDTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/SubDTest.cpp
@@ -415,9 +415,13 @@ void sparseTest()
 
         // only set UVs
         OSubDSchema::Sample meshSamp;
+
+        TESTING_ASSERT( !meshSamp.isPartialSample() );
+
         OV2fGeomParam::Sample uvSample( V2fArraySample( (const V2f *)g_uvs,
             g_numUVs ), kFacevaryingScope );
         meshSamp.setUVs( uvSample );
+        TESTING_ASSERT( meshSamp.isPartialSample() );
         meshUVsObj.getSchema().set( meshSamp );
 
         // only set pts

--- a/maya/AbcExport/AbcExport.cpp
+++ b/maya/AbcExport/AbcExport.cpp
@@ -841,7 +841,7 @@ try
                 }
 
                 // pattern mismatch, we use acyclic time sampling type
-                if (timeSamples[i] != pattern[i % pattern.size()])
+                if (fabs(timeSamples[i] - pattern[i % pattern.size()]) > 0.00001)
                 {
                     isAcyclic = true;
                     break;


### PR DESCRIPTION
Fix an AbcExport issue mentioned on the forums where acyclic sampling was being chosen because of floating point precisions issues.

Fix a bug discovered when trying to add empty samples to SubDs in AbcStitcher, it was treating face counts and face indices as partial data.