### PR TITLE
Make easier to select a python version to build against

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -74,7 +74,7 @@ Some examples of OPTIONS you may want or need to use include:
     an arbitrary location.
 
     -DPython_ADDITIONAL_VERSIONS=3  If you want to build Alembic against Python
-    3. See !(the CMake module documentation)[https://cmake.org/cmake/help/latest/module/FindPythonInterp.html].
+    3. See [the CMake module documentation](https://cmake.org/cmake/help/latest/module/FindPythonInterp.html).
 
 For Unix like operating systems:
 

--- a/README.txt
+++ b/README.txt
@@ -73,6 +73,9 @@ Some examples of OPTIONS you may want or need to use include:
     -DCMAKE_INSTALL_PREFIX=customPath  If you want to install the Alembic into
     an arbitrary location.
 
+    -DPython_ADDITIONAL_VERSIONS=3  If you want to build Alembic against Python
+    3. See !(the CMake module documentation)[https://cmake.org/cmake/help/latest/module/FindPythonInterp.html].
+
 For Unix like operating systems:
 
 3a) Run the make command.  Kind of a no-brainer, really.  You can safely run

--- a/README.txt
+++ b/README.txt
@@ -74,7 +74,7 @@ Some examples of OPTIONS you may want or need to use include:
     an arbitrary location.
 
     -DPython_ADDITIONAL_VERSIONS=3  If you want to build Alembic against Python
-    3. See [the CMake module documentation](https://cmake.org/cmake/help/latest/module/FindPythonInterp.html).
+    3. See the [CMake module documentation](https://cmake.org/cmake/help/latest/module/FindPythonInterp.html).
 
 For Unix like operating systems:
 

--- a/cmake/AlembicPython.cmake
+++ b/cmake/AlembicPython.cmake
@@ -33,8 +33,12 @@
 ##
 ##-*****************************************************************************
 
-FIND_PACKAGE ( PythonInterp 2 REQUIRED )
-FIND_PACKAGE ( PythonLibs 2 REQUIRED )
+if (NOT EXISTS Python_ADDITIONAL_VERSIONS)
+  set(Python_ADDITIONAL_VERSIONS 2)
+endif()
+
+FIND_PACKAGE ( PythonInterp REQUIRED )
+FIND_PACKAGE ( PythonLibs REQUIRED )
 IF(PYTHONLIBS_FOUND)
     SET(ALEMBIC_PYTHON_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
     SET(ALEMBIC_PYTHON_LIBRARY ${PYTHON_LIBRARIES})

--- a/cmake/AlembicPython.cmake
+++ b/cmake/AlembicPython.cmake
@@ -33,7 +33,7 @@
 ##
 ##-*****************************************************************************
 
-if (NOT EXISTS Python_ADDITIONAL_VERSIONS)
+if (NOT DEFINED Python_ADDITIONAL_VERSIONS)
   set(Python_ADDITIONAL_VERSIONS 2)
 endif()
 


### PR DESCRIPTION
This PR removes the explicit Python version (was: v2) in the cmake modules `PythonInterp` and `PythonLibs`. This allows to specify a list of python versions with the standard variable [Python_ADDITIONAL_VERSIONS](https://cmake.org/cmake/help/latest/module/FindPythonInterp.html). This is useful to ensure a build against Python 3 when both Python 2 and 3 are available.

The previous behavior of having python 2 as default is kept. The README has been updated to mention `python_ADDITIONAL_VERSIONS`.