### PR TITLE
Support writing animated facesets out of Maya.

### DIFF
--- a/maya/AbcExport/AbcWriteJob.cpp
+++ b/maya/AbcExport/AbcWriteJob.cpp
@@ -364,7 +364,7 @@ bool AbcWriteJob::checkCurveGrp()
     return true;
 }
 
-void AbcWriteJob::setup(double iFrame, MayaTransformWriterPtr iParent, GetMembersMap& gmMap)
+void AbcWriteJob::setup(double iFrame, MayaTransformWriterPtr iParent)
 {
     MStatus status;
 
@@ -489,7 +489,7 @@ void AbcWriteJob::setup(double iFrame, MayaTransformWriterPtr iParent, GetMember
         {
             if (mCurDag.push(mCurDag.child(i)) == MS::kSuccess)
             {
-                setup(iFrame, trans, gmMap);
+                setup(iFrame, trans);
                 mCurDag.pop();
             }
         }
@@ -605,7 +605,7 @@ void AbcWriteJob::setup(double iFrame, MayaTransformWriterPtr iParent, GetMember
         {
             Alembic::Abc::OObject obj = iParent->getObject();
             MayaMeshWriterPtr mesh(new MayaMeshWriter(mCurDag, obj,
-                mShapeTimeIndex, mArgs, gmMap));
+                mShapeTimeIndex, mArgs));
 
             if (mesh->isAnimated() && mShapeTimeIndex != 0)
             {
@@ -642,6 +642,18 @@ void AbcWriteJob::setup(double iFrame, MayaTransformWriterPtr iParent, GetMember
             AttributesWriterPtr attrs = mesh->getAttrs();
             if (mShapeTimeIndex != 0 && attrs->isAnimated())
                 mShapeAttrList.push_back(attrs);
+
+            if (mShapeTimeIndex != 0)
+            {
+                std::vector< MayaFaceSetWriterPtr >::iterator it;
+                for (it = mesh->beginFaces(); it != mesh->endFaces(); ++it)
+                {
+                    if ((*it)->getAttrs() && (*it)->getAttrs()->isAnimated())
+                    {
+                        mShapeAttrList.push_back((*it)->getAttrs());
+                    }
+                }
+            }
         }
         else
         {
@@ -857,12 +869,11 @@ bool AbcWriteJob::eval(double iFrame)
         mArgs.setFirstAnimShape = (iFrame == *mShapeFrames.begin());
 
         util::ShapeSet::const_iterator end = mArgs.dagPaths.end();
-        GetMembersMap gmMap;
         for (util::ShapeSet::const_iterator it = mArgs.dagPaths.begin();
             it != end; ++it)
         {
             mCurDag = *it;
-            setup(iFrame * util::spf(), MayaTransformWriterPtr(), gmMap);
+            setup(iFrame * util::spf(), MayaTransformWriterPtr());
         }
         perFrameCallback(iFrame);
     }

--- a/maya/AbcExport/AbcWriteJob.h
+++ b/maya/AbcExport/AbcWriteJob.h
@@ -171,8 +171,7 @@ class AbcWriteJob
     void postCallback(double iFrame);
 
     MBoundingBox getBoundingBox(double iFrame, const MMatrix & eMInvMat);
-    void setup(double iFrame, MayaTransformWriterPtr iParent,
-               GetMembersMap& gmMap);
+    void setup(double iFrame, MayaTransformWriterPtr iParent);
 
     // Currently Arnold and Renderman can not handle curve groups where the
     // degrees and closed status are different per curve.

--- a/maya/AbcExport/CMakeLists.txt
+++ b/maya/AbcExport/CMakeLists.txt
@@ -40,6 +40,7 @@ SET(H_FILES
     AttributesWriter.h
     Foundation.h
     MayaCameraWriter.h
+    MayaFaceSetWriter.h
     MayaMeshWriter.h
     MayaLocatorWriter.h
     MayaNurbsCurveWriter.h
@@ -54,6 +55,7 @@ SET(CXX_FILES
     AbcWriteJob.cpp
     AttributesWriter.cpp
     MayaCameraWriter.cpp
+    MayaFaceSetWriter.cpp
     MayaMeshWriter.cpp
     MayaLocatorWriter.cpp
     MayaNurbsCurveWriter.cpp

--- a/maya/AbcExport/Foundation.h
+++ b/maya/AbcExport/Foundation.h
@@ -58,6 +58,7 @@
 #include <maya/MFnAmbientLight.h>
 #include <maya/MFnAttribute.h>
 #include <maya/MFnCamera.h>
+#include <maya/MFnComponentListData.h>
 #include <maya/MFnDagNode.h>
 #include <maya/MFnData.h>
 #include <maya/MFnDependencyNode.h>

--- a/maya/AbcExport/MayaFaceSetWriter.cpp
+++ b/maya/AbcExport/MayaFaceSetWriter.cpp
@@ -1,0 +1,106 @@
+//-*****************************************************************************
+//
+// Copyright (c) 2009-2019,
+//  Sony Pictures Imageworks Inc. and
+//  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Sony Pictures Imageworks, nor
+// Industrial Light & Magic, nor the names of their contributors may be used
+// to endorse or promote products derived from this software without specific
+// prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//-*****************************************************************************
+
+#include "MayaFaceSetWriter.h"
+#include "MayaUtility.h"
+
+MayaFaceSetWriter::MayaFaceSetWriter(MObject & iNameObj, MPlug & iPlug,
+    Alembic::Abc::OObject & iParent,
+    Alembic::Util::uint32_t iTimeIndex,
+    const JobArgs & iArgs)
+{
+    mPlug = iPlug;
+
+    MFnDependencyNode fnDepNode(iNameObj);
+    MString faceSetName = fnDepNode.name();
+    faceSetName = util::stripNamespaces(faceSetName, iArgs.stripNamespace);
+    MPlug abcFacesetNamePlug = fnDepNode.findPlug("AbcFacesetName", true);
+    if (!abcFacesetNamePlug.isNull())
+    {
+        faceSetName = abcFacesetNamePlug.asString();
+    }
+
+    Alembic::AbcGeom::OFaceSet fs(iParent, faceSetName.asChar(), iTimeIndex);
+    mSchema = fs.getSchema();
+    mSchema.setFaceExclusivity(Alembic::AbcGeom::kFaceSetExclusive);
+
+    Alembic::Abc::OCompoundProperty cp;
+    Alembic::Abc::OCompoundProperty up;
+    if (AttributesWriter::hasAnyAttr(fnDepNode, iArgs))
+    {
+        cp = mSchema.getArbGeomParams();
+        up = mSchema.getUserProperties();
+        mAttrs = AttributesWriterPtr(new AttributesWriter(cp, up, fs,
+            fnDepNode, iTimeIndex, iArgs, true));
+    }
+
+    write();
+}
+
+
+void MayaFaceSetWriter::write()
+{
+    MObject indexedObj;
+
+    MFnComponentListData cmptList(mPlug.asMObject());
+
+    unsigned int numPolyCmpt = 0;
+    for(unsigned int i = 0; i < cmptList.length(); ++i)
+    {
+        if (cmptList[i].apiType() == MFn::kMeshPolygonComponent)
+        {
+            indexedObj = cmptList[i];
+            numPolyCmpt ++;
+        }
+    }
+
+    // retrieve the face indices
+    MIntArray indices;
+    MFnSingleIndexedComponent compFn;
+    compFn.setObject(indexedObj);
+    compFn.getElements(indices);
+    const unsigned int numData = indices.length();
+
+    std::vector<Alembic::Util::int32_t> faceIndices(numData);
+    for (unsigned int j = 0; j < numData; ++j)
+    {
+        faceIndices[j] = indices[j];
+    }
+
+    Alembic::AbcGeom::OFaceSetSchema::Sample samp;
+    samp.setFaces(Alembic::Abc::Int32ArraySample(faceIndices));
+    mSchema.set(samp);
+}

--- a/maya/AbcExport/MayaFaceSetWriter.h
+++ b/maya/AbcExport/MayaFaceSetWriter.h
@@ -46,7 +46,7 @@
 class MayaFaceSetWriter
 {
   public:
-    MayaFaceSetWriter(MObject & iNameObj, MPlug & iPlug,
+    MayaFaceSetWriter(MObject & iNameObj, std::vector<MPlug> & iPlugVec,
         Alembic::Abc::OObject & iParent,
         Alembic::Util::uint32_t iTimeIndex,
         const JobArgs & iArgs);
@@ -56,7 +56,7 @@ class MayaFaceSetWriter
   private:
     AttributesWriterPtr mAttrs;
     Alembic::AbcGeom::OFaceSetSchema mSchema;
-    MPlug mPlug;
+    std::vector<MPlug> mPlugVec;
 };
 
 typedef Alembic::Util::shared_ptr < MayaFaceSetWriter >

--- a/maya/AbcExport/MayaFaceSetWriter.h
+++ b/maya/AbcExport/MayaFaceSetWriter.h
@@ -1,6 +1,6 @@
 //-*****************************************************************************
 //
-// Copyright (c) 2009-2014,
+// Copyright (c) 2009-2019,
 //  Sony Pictures Imageworks Inc. and
 //  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
 //
@@ -34,67 +34,32 @@
 //
 //-*****************************************************************************
 
-#ifndef AbcExport_MayaMeshWriter_h
-#define AbcExport_MayaMeshWriter_h
+#ifndef AbcExport_MayaFaceSetWriter_h
+#define AbcExport_MayaFaceSetWriter_h
 
 #include "Foundation.h"
 #include "AttributesWriter.h"
-#include "MayaFaceSetWriter.h"
+#include <Alembic/AbcGeom/OFaceSet.h>
+#include <maya/MFnSingleIndexedComponent.h>
 
 // Writes an MFnMesh as a poly mesh OR a subd mesh
-class MayaMeshWriter
+class MayaFaceSetWriter
 {
   public:
+    MayaFaceSetWriter(MObject & iNameObj, MPlug & iPlug,
+        Alembic::Abc::OObject & iParent,
+        Alembic::Util::uint32_t iTimeIndex,
+        const JobArgs & iArgs);
 
-    MayaMeshWriter(MDagPath & iDag, Alembic::Abc::OObject & iParent,
-        Alembic::Util::uint32_t iTimeIndex, const JobArgs & iArgs);
     void write();
-    bool isAnimated() const;
-    bool isSubD();
-    unsigned int getNumCVs();
-    unsigned int getNumFaces();
     AttributesWriterPtr getAttrs() {return mAttrs;};
-
-    std::vector< MayaFaceSetWriterPtr >::iterator beginFaces() {return mFaceSets.begin();};
-    std::vector< MayaFaceSetWriterPtr >::iterator endFaces() {return mFaceSets.end();};
   private:
-
-    void fillTopology(
-        std::vector<float> & oPoints,
-        std::vector<Alembic::Util::int32_t> & oFacePoints,
-        std::vector<Alembic::Util::int32_t> & oPointCounts);
-
-    void writePoly(const Alembic::AbcGeom::OV2fGeomParam::Sample & iUVs);
-
-    void writeSubD(const Alembic::AbcGeom::OV2fGeomParam::Sample & iUVs);
-
-    void getUVs(std::vector<float> & uvs,
-        std::vector<Alembic::Util::uint32_t> & indices,
-        std::string & name);
-
-    void getPolyNormals(std::vector<float> & oNormals);
-    bool mNoNormals;
-    bool mWriteGeometry;
-    bool mWriteUVs;
-    bool mWriteColorSets;
-    bool mWriteUVSets;
-
-    bool mIsGeometryAnimated;
-    MDagPath mDagPath;
-
     AttributesWriterPtr mAttrs;
-    Alembic::AbcGeom::OPolyMeshSchema mPolySchema;
-    Alembic::AbcGeom::OSubDSchema     mSubDSchema;
-
-    void writeColor();
-    std::vector<Alembic::AbcGeom::OC3fGeomParam> mRGBParams;
-    std::vector<Alembic::AbcGeom::OC4fGeomParam> mRGBAParams;
-
-    void writeUVSets();
-    typedef std::vector<Alembic::AbcGeom::OV2fGeomParam> UVParamsVec;
-    UVParamsVec mUVparams;
-
-    std::vector< MayaFaceSetWriterPtr > mFaceSets;
+    Alembic::AbcGeom::OFaceSetSchema mSchema;
+    MPlug mPlug;
 };
 
-#endif  // AbcExport_MayaMeshWriter_h
+typedef Alembic::Util::shared_ptr < MayaFaceSetWriter >
+    MayaFaceSetWriterPtr;
+
+#endif  // AbcExport_MayaFaceSetWriter_h

--- a/maya/AbcExport/MayaMeshWriter.cpp
+++ b/maya/AbcExport/MayaMeshWriter.cpp
@@ -128,120 +128,6 @@ void getUVSet(const MFnMesh & iMesh, const MString & iUVSetName,
     }
 }
 
-// --------------------------------------------------------------
-// getOutConnectedSG( const MObject &shape )
-//
-// Return the output connected shading groups from a shape object
-//---------------------------------------------------------------
-
-MObjectArray
-getOutConnectedSG( const MDagPath &shapeDPath )
-{
-    MStatus status;
-
-    // Array of connected Shaging Engines
-    MObjectArray connSG;
-
-    // Iterator through the dependency graph to find if there are
-    // shading engines connected
-    MObject obj(shapeDPath.node()); // non const MObject
-    MItDependencyGraph itDG( obj, MFn::kShadingEngine,
-                             MItDependencyGraph::kDownstream,
-                             MItDependencyGraph::kBreadthFirst,
-                             MItDependencyGraph::kNodeLevel, &status );
-
-    if( status == MS::kFailure )
-        return connSG;
-
-    // we want to prune the iteration if the node is not a shading engine
-    itDG.enablePruningOnFilter();
-
-    // iterate through the output connected shading engines
-    for( ; itDG.isDone()!= true; itDG.next() )
-        connSG.append( itDG.currentItem() );
-
-    return connSG;
-}
-
-// -----------------------------------------------------------------------------------------------------------
-// getSetComponents( const MDagPath &dagPath, const MObject &SG, GetMembersMap& gmMap, MObject &compObj )
-//
-// Return the members of a shading engine for a specific dagpath.
-// GetMembersMap is a caching mechanism.
-// If it's face mapping, return the indices, otherwise it's the whole object, and so we
-// return kFailure.
-//------------------------------------------------------------------------------------------------------------
-
-MStatus
-getSetComponents( const MDagPath &dagPath, const MObject &SG, GetMembersMap& gmMap, MObject &compObj )
-{
-    const MString instObjGroupsAttrName( "instObjGroups" );
-
-    // Check if SG is really a shading engine
-    if( SG.hasFn(MFn::kShadingEngine) != true )
-    {
-        MFnDependencyNode fnDepNode( SG );
-        MString message;
-        message.format("Node ^1s is not a valid shading engine...", fnDepNode.name() );
-        MGlobal::displayError(message);
-
-        return MS::kFailure;
-    }
-
-    // get the instObjGroups iog plug
-    MStatus status;
-    MFnDependencyNode depNode(dagPath.node());
-    MPlug iogPlug( depNode.findPlug(instObjGroupsAttrName, false, &status) );
-    if( status == MS::kFailure )
-        return MS::kFailure;
-
-    // if there are no elements,  this shading group is not connected as a face set
-    if( iogPlug.numElements()<=0 )
-        return MS::kFailure;
-
-    // the first element should always be connected as a source
-    MPlugArray iogConnections;
-    iogPlug.elementByLogicalIndex(0, &status).connectedTo(iogConnections, false, true, &status );
-    if( status == MS::kFailure )
-        return MS::kFailure;
-
-    // Function set for the shading engine
-    MFnSet fnSet( SG );
-
-    // Retrieve members
-    MSelectionList selList;
-    GetMembersMap::iterator it = gmMap.find(SG);
-    if(it != gmMap.end())
-        selList = it->second;
-    else
-    {
-        fnSet.getMembers(selList, false);
-        gmMap[SG] = selList;
-    }
-
-    // Iteration through the list
-    MDagPath            curDagPath;
-    MItSelectionList    itSelList( selList );
-    for( ; itSelList.isDone()!=true; itSelList.next() )
-    {
-        // Test if it's a face mapping
-        if( itSelList.hasComponents() == true )
-        {
-            itSelList.getDagPath( curDagPath, compObj );
-
-            // Test if component object is valid and if it's the right object
-            if( (compObj.isNull()==false) && (curDagPath==dagPath) )
-            {
-                return MS::kSuccess;
-            }
-        }
-    }
-
-    // SG is a shading engine but has no components connected to the dagPath.
-    // This means we have a whole object mapping!
-    return MS::kFailure;
-}
-
 }
 
 void MayaMeshWriter::getUVs(std::vector<float> & uvs,
@@ -301,7 +187,7 @@ void MayaMeshWriter::getUVs(std::vector<float> & uvs,
 
 MayaMeshWriter::MayaMeshWriter(MDagPath & iDag,
     Alembic::Abc::OObject & iParent, Alembic::Util::uint32_t iTimeIndex,
-    const JobArgs & iArgs, GetMembersMap& gmMap)
+    const JobArgs & iArgs)
   : mNoNormals(iArgs.noNormals),
     mWriteGeometry(iArgs.writeGeometry),
     mWriteUVs(iArgs.writeUVs),
@@ -565,102 +451,94 @@ MayaMeshWriter::MayaMeshWriter(MDagPath & iDag,
     if(!iArgs.writeFaceSets)
         return;
 
-    // get the connected shading engines
-    MObjectArray connSGObjs (getOutConnectedSG(mDagPath));
-    const unsigned int sgCount = connSGObjs.length();
-
-    for (unsigned int i = 0; i < sgCount; ++i)
+    MFnDependencyNode meshDep(mDagPath.node());
+    MPlug iogPlug( meshDep.findPlug("instObjGroups", false, &status) );
+    if( status == MS::kFailure )
     {
-        MObject connSGObj, compObj;
-
-        connSGObj = connSGObjs[i];
-
-        MFnDependencyNode fnDepNode(connSGObj);
-        MString connSgObjName = fnDepNode.name();
-
-        // retrive the component MObject
-        status = getSetComponents(mDagPath, connSGObj, gmMap, compObj);
-
-        if (status != MS::kSuccess)
-        {
-            // for some reason the shading group doesn't represent a face set
-            continue;
-        }
-
-        // retrieve the face indices
-        MIntArray indices;
-        MFnSingleIndexedComponent compFn;
-        compFn.setObject(compObj);
-        compFn.getElements(indices);
-        const unsigned int numData = indices.length();
-
-        // encountered the whole object mapping. skip it.
-        if (numData == 0)
-            continue;
-
-        std::vector<Alembic::Util::int32_t> faceIndices(numData);
-        for (unsigned int j = 0; j < numData; ++j)
-        {
-            faceIndices[j] = indices[j];
-        }
-
-        connSgObjName = util::stripNamespaces(connSgObjName,
-                                              iArgs.stripNamespace);
-
-        Alembic::AbcGeom::OFaceSet faceSet;
-        std::string faceSetName(connSgObjName.asChar());
-
-        MPlug abcFacesetNamePlug = fnDepNode.findPlug("AbcFacesetName", true);
-        if (!abcFacesetNamePlug.isNull())
-        {
-            faceSetName = abcFacesetNamePlug.asString().asChar();
-        }
-
-        if (mPolySchema.valid())
-        {
-            if (mPolySchema.hasFaceSet(faceSetName))
-            {
-                faceSet = mPolySchema.getFaceSet(faceSetName);
-            }
-            else
-            {
-                faceSet = mPolySchema.createFaceSet(faceSetName);
-            }
-        }
-        else
-        {
-            if (mSubDSchema.hasFaceSet(faceSetName))
-            {
-                faceSet = mSubDSchema.getFaceSet(faceSetName);
-            }
-            else
-            {
-                faceSet = mSubDSchema.createFaceSet(faceSetName);
-            }
-        }
-        Alembic::AbcGeom::OFaceSetSchema::Sample samp;
-        samp.setFaces(Alembic::Abc::Int32ArraySample(faceIndices));
-
-        Alembic::AbcGeom::OFaceSetSchema faceSetSchema = faceSet.getSchema();
-
-        faceSetSchema.set(samp);
-        faceSetSchema.setFaceExclusivity(Alembic::AbcGeom::kFaceSetExclusive);
-
-        MFnDependencyNode iNode(connSGObj);
-
-        Alembic::Abc::OCompoundProperty cp;
-        Alembic::Abc::OCompoundProperty up;
-        if (AttributesWriter::hasAnyAttr(iNode, iArgs))
-        {
-            cp = faceSetSchema.getArbGeomParams();
-            up = faceSetSchema.getUserProperties();
-        }
-
-        // last argument false so we set the animated attrs at least once
-        // because we don't appear to support animated facesets yet
-        AttributesWriter attrWriter(cp, up, faceSet, iNode, iTimeIndex,
-                                    iArgs, false);
+        return;
     }
+
+    // mesh.instObjGroups is an array of compounds
+    for (unsigned int i = 0; i < iogPlug.numElements(); ++i)
+    {
+        MPlug compPlug = iogPlug.elementByPhysicalIndex(i);
+        for (unsigned int j = 0; j < compPlug.numChildren(); ++j)
+        {
+            // no elements in the child could mean the whole mesh is shaded
+            MPlug objGroupPlug = compPlug.child(j);
+            for (unsigned int k = 0; k < objGroupPlug.numElements(); ++k)
+            {
+                // mesh.instObjGroups[i].objectGroups[k]
+                MPlug objGrpCompPlug = objGroupPlug.elementByPhysicalIndex(k);
+                if (objGrpCompPlug.isNull())
+                {
+                    continue;
+                }
+
+                MPlugArray dests;
+                if (!objGrpCompPlug.destinations(dests))
+                {
+                    continue;
+                }
+
+                MObject shadingObj;
+
+                // look for a shading engine, can we have more than 1?
+                for (unsigned int p = 0; p < dests.length(); ++p)
+                {
+                    if (dests[p].isNull())
+                    {
+                        continue;
+                    }
+
+                    MObject testObj = dests[p].node();
+                    if (!testObj.hasFn(MFn::kShadingEngine))
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        shadingObj = testObj;
+                    }
+                }
+
+                if (shadingObj.isNull())
+                {
+                    continue;
+                }
+
+                // mesh.instObjGroups[i].objectGroups[k].objectGrpCompList
+                for (unsigned int l = 0; l < objGrpCompPlug.numChildren(); ++l)
+                {
+                    MPlug childPlug = objGrpCompPlug.child(l);
+                    MString plugName = childPlug.name();
+                    plugName = plugName.substringW(plugName.length() - 17, plugName.length() - 1);
+                    if (plugName == "objectGrpCompList")
+                    {
+                        Alembic::Abc::OObject parentObj;
+                        if (mPolySchema.valid())
+                        {
+                            parentObj = mPolySchema.getObject();
+                        }
+                        else
+                        {
+                            parentObj = mSubDSchema.getObject();
+                        }
+
+                        MayaFaceSetWriterPtr facePtr(new MayaFaceSetWriter(
+                            shadingObj, childPlug, parentObj,
+                            iTimeIndex, iArgs));
+                        mFaceSets.push_back(facePtr);
+
+                        // we can move on to the next
+                        // mesh.instObjGroups[i].objectGroups[k]
+                        break;
+                    }
+                } //  for l
+            } // for k
+        } // for j
+    } // for i
+
 }
 
 bool MayaMeshWriter::isSubD()
@@ -940,6 +818,13 @@ void MayaMeshWriter::write()
     {
         writeSubD(uvSamp);
     }
+
+    std::vector< MayaFaceSetWriterPtr >::iterator it;
+    for (it = mFaceSets.begin(); it != mFaceSets.end(); ++it)
+    {
+        (*it)->write();
+    }
+
 }
 
 bool MayaMeshWriter::isAnimated() const


### PR DESCRIPTION
Rework the faceset writing to support animated facesets.

Since the shading engine doesn't seem to update, we instead need to look at
this plug:

shape.instObjGroups[i].objectGroups[j].objectGrpCompList