### PR TITLE
Use critical section instead of mutex on windows.

### DIFF
--- a/lib/Alembic/Util/Foundation.h
+++ b/lib/Alembic/Util/Foundation.h
@@ -221,26 +221,26 @@ class mutex : noncopyable
 public:
     mutex()
     {
-        m = CreateMutex( NULL, FALSE, NULL );
+         InitializeCriticalSection(&cs);
     }
 
     ~mutex()
     {
-        CloseHandle( m );
+        DeleteCriticalSection(&cs);
     }
 
     void lock()
     {
-        WaitForSingleObject( m, INFINITE );
+        EnterCriticalSection(&cs);
     }
 
     void unlock()
     {
-        ReleaseMutex( m );
+        LeaveCriticalSection(&cs);
     }
 
 private:
-    HANDLE m;
+    CRITICAL_SECTION cs;
 };
 
 #else


### PR DESCRIPTION
Implement the windows version of alembic's mutex
with native critical section to avoid kernel calls.
https://blogs.msdn.microsoft.com/ce_base/2007/03/26/critical-section-vs-mutex/

Based on my tests this version is at least 20% faster for single and multi-threaded usage.