### PR TITLE
ErrorHandler's Context now use const char * instead of std::string for its message member.

### DIFF
--- a/lib/Alembic/Abc/ErrorHandler.h
+++ b/lib/Alembic/Abc/ErrorHandler.h
@@ -92,7 +92,7 @@ public:
     class Context
     {
     public:
-        Context( ErrorHandler &iEhnd, const std::string &iCtxMsg )
+        Context( ErrorHandler &iEhnd, const char *iCtxMsg )
           : m_handler( iEhnd ),
             m_message( iCtxMsg ) {}
 
@@ -114,7 +114,7 @@ public:
     private:
         const Context& operator= (const Context&);
         ErrorHandler &m_handler;
-        std::string m_message;
+        const char *m_message;
     };
 
 private:


### PR DESCRIPTION
ALEMBIC_ABC_SAFE_CALL_BEGIN is used a lot and it creates
ErrorHandler::Context, On other hand the Context allocates std::string this causes many new/delete calls that could be avoided. The performance impact of this change is huge (especially on Windows).

The drawback:
ALEMBIC_ABC_SAFE_CALL_BEGIN have to be used only with literals (as at the moment).