### PR TITLE
Fixed missing UV and normals when converting OBJ files with more than…

### DIFF
--- a/examples/AbcClients/WFObjConvert/AbcReader.cpp
+++ b/examples/AbcClients/WFObjConvert/AbcReader.cpp
@@ -210,6 +210,8 @@ void AbcReader::makeCurrentObject()
     }
 
     m_indices.clear();
+    m_texIndices.clear();
+    m_normIndices.clear();
     m_counts.clear();
     m_currentObjectName = "";
 }


### PR DESCRIPTION
The OBJ to Alembic translator failed to translate UVs and Normals for OBJ files with more than one part in them.  The reason was that the UV & Normal index lists were not getting reset after each part.  This caused an index list size check to fail for UV & normals, thus they weren't copied over to the new part.
