### PR TITLE
Use double when retrieving Maya time

### DIFF
--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -382,17 +382,17 @@ MStatus AlembicNode::initialize()
 
 double AlembicNode::getFPS()
 {
-    float fps = 24.0f;
+    double fps = 24.0;
     MTime::Unit unit = MTime::uiUnit();
     if (unit!=MTime::kInvalid)
     {
         MTime time(1.0, MTime::kSeconds);
-        fps = static_cast<float>(time.as(unit));
+        fps = time.as(unit);
     }
 
-    if (fps <= 0.f )
+    if (fps <= 0.0 )
     {
-        fps = 24.0f;
+        fps = 24.0;
     }
 
     return fps;


### PR DESCRIPTION
This should prevent precision loss when dealing with frame rates such as 23.976.

This should fix: https://github.com/alembic/alembic/issues/234

Test needed to confirm.