### PR TITLE
Per Issue 238: Support per curve (kUniform) width in Maya.

### DIFF
--- a/maya/AbcExport/MayaNurbsCurveWriter.cpp
+++ b/maya/AbcExport/MayaNurbsCurveWriter.cpp
@@ -337,6 +337,7 @@ void MayaNurbsCurveWriter::write()
                     width.push_back(static_cast<float>(doubleArrayData[i]));
                 }
             }
+            // successfully got as a double array but not enough values!
             else if (status == MS::kSuccess)
             {
                 MString msg = "Curve ";
@@ -352,9 +353,10 @@ void MayaNurbsCurveWriter::write()
             else
             {
                 width.push_back(widthPlug.asFloat());
-                useConstWidth = true;
             }
         }
+        // no width plug on the curve, but not yet noticed as constant width
+        // force constant
         else if (!useConstWidth)
         {
             // pick a default value
@@ -365,8 +367,15 @@ void MayaNurbsCurveWriter::write()
     }
 
     Alembic::AbcGeom::GeometryScope scope = Alembic::AbcGeom::kVertexScope;
-    if (useConstWidth)
+    if (!useConstWidth && width.size() > 1 && width.size() == numCurves)
+    {
+        scope = Alembic::AbcGeom::kUniformScope;
+    }
+    else
+    {
         scope = Alembic::AbcGeom::kConstantScope;
+    }
+
 
     samp.setCurvesNumVertices(Alembic::Abc::Int32ArraySample(nVertices));
     samp.setPositions(Alembic::Abc::V3fArraySample(

--- a/maya/AbcExport/MayaNurbsCurveWriter.cpp
+++ b/maya/AbcExport/MayaNurbsCurveWriter.cpp
@@ -371,7 +371,7 @@ void MayaNurbsCurveWriter::write()
     {
         scope = Alembic::AbcGeom::kUniformScope;
     }
-    else
+    else if (width.size() == 1)
     {
         scope = Alembic::AbcGeom::kConstantScope;
     }

--- a/maya/AbcImport/NurbsCurveHelper.cpp
+++ b/maya/AbcImport/NurbsCurveHelper.cpp
@@ -390,6 +390,15 @@ MObject createCurves(const std::string & iName,
             curve.addAttribute(attrObj);
             curve.findPlug("width", true).setValue((*widths)[0]);
         }
+        else if (widths && widths->size() == numCurves &&
+                 iWidths.getScope() ==  Alembic::AbcGeom::kUniformScope)
+        {
+            MFnNumericAttribute widthAttr;
+            MObject attrObj = widthAttr.create("width",
+                "width", MFnNumericData::kFloat, (*widths)[i]);
+            curve.addAttribute(attrObj);
+            curve.findPlug("width", true).setValue((*widths)[i]);
+        }
         // per vertex width
         else if (widths && widths->size() >= curVert && numVerts > 0 &&
             iWidths.getScope() ==  Alembic::AbcGeom::kVertexScope)

--- a/maya/Tests/eulerFilter_test.py
+++ b/maya/Tests/eulerFilter_test.py
@@ -178,14 +178,14 @@ class EulerFilterTest(unittest.TestCase):
         self.failUnlessAlmostEqual(270, MayaCmds.getAttr('test.rotateZ'))
         self.failUnlessAlmostEqual(90, MayaCmds.getAttr('test.rotateAxisX'))
         self.failUnlessAlmostEqual(-10, MayaCmds.getAttr('test.rotateAxisY'))
-        self.failUnlessAlmostEqual(-90, MayaCmds.getAttr('test.rotateAxisZ'))
+        self.failUnlessAlmostEqual(270, MayaCmds.getAttr('test.rotateAxisZ'))
 
         MayaCmds.currentTime(2, update = True)
         self.assertEqual(1, MayaCmds.getAttr('test.rotateOrder'))
         self.failUnlessAlmostEqual(460, MayaCmds.getAttr('test.rotateX'))
         self.failUnlessAlmostEqual(-40, MayaCmds.getAttr('test.rotateY'))
         self.failUnlessAlmostEqual(0, MayaCmds.getAttr('test.rotateZ'))
-        self.failUnlessAlmostEqual(100, MayaCmds.getAttr('test.rotateAxisX'))
+        self.failUnlessAlmostEqual(460, MayaCmds.getAttr('test.rotateAxisX'))
         self.failUnlessAlmostEqual(-40, MayaCmds.getAttr('test.rotateAxisY'))
         self.failUnlessAlmostEqual(0, MayaCmds.getAttr('test.rotateAxisZ'))
 
@@ -195,8 +195,8 @@ class EulerFilterTest(unittest.TestCase):
         self.failUnlessAlmostEqual(290, MayaCmds.getAttr('test.rotateY'))
         self.failUnlessAlmostEqual(810, MayaCmds.getAttr('test.rotateZ'))
         self.failUnlessAlmostEqual(110, MayaCmds.getAttr('test.rotateAxisX'))
-        self.failUnlessAlmostEqual(-70, MayaCmds.getAttr('test.rotateAxisY'))
-        self.failUnlessAlmostEqual(90, MayaCmds.getAttr('test.rotateAxisZ'))
+        self.failUnlessAlmostEqual(290, MayaCmds.getAttr('test.rotateAxisY'))
+        self.failUnlessAlmostEqual(810, MayaCmds.getAttr('test.rotateAxisZ'))
 
         # Check file with euler filter
         MayaCmds.AbcImport(self.__files[-1], mode='open')
@@ -209,7 +209,7 @@ class EulerFilterTest(unittest.TestCase):
         self.failUnlessAlmostEqual(270, MayaCmds.getAttr('test.rotateZ'))
         self.failUnlessAlmostEqual(90, MayaCmds.getAttr('test.rotateAxisX'))
         self.failUnlessAlmostEqual(-10, MayaCmds.getAttr('test.rotateAxisY'))
-        self.failUnlessAlmostEqual(-90, MayaCmds.getAttr('test.rotateAxisZ'))
+        self.failUnlessAlmostEqual(270, MayaCmds.getAttr('test.rotateAxisZ'))
 
         MayaCmds.currentTime(2, update = True)
         self.assertEqual(1, MayaCmds.getAttr('test.rotateOrder'))
@@ -218,7 +218,7 @@ class EulerFilterTest(unittest.TestCase):
         self.failUnlessAlmostEqual(360, MayaCmds.getAttr('test.rotateZ'))
         self.failUnlessAlmostEqual(100, MayaCmds.getAttr('test.rotateAxisX'))
         self.failUnlessAlmostEqual(-40, MayaCmds.getAttr('test.rotateAxisY'))
-        self.failUnlessAlmostEqual(0, MayaCmds.getAttr('test.rotateAxisZ'))
+        self.failUnlessAlmostEqual(360, MayaCmds.getAttr('test.rotateAxisZ'))
 
         MayaCmds.currentTime(3, update = True)
         self.assertEqual(1, MayaCmds.getAttr('test.rotateOrder'))
@@ -227,5 +227,5 @@ class EulerFilterTest(unittest.TestCase):
         self.failUnlessAlmostEqual(450, MayaCmds.getAttr('test.rotateZ'))
         self.failUnlessAlmostEqual(110, MayaCmds.getAttr('test.rotateAxisX'))
         self.failUnlessAlmostEqual(-70, MayaCmds.getAttr('test.rotateAxisY'))
-        self.failUnlessAlmostEqual(90, MayaCmds.getAttr('test.rotateAxisZ'))
+        self.failUnlessAlmostEqual(450, MayaCmds.getAttr('test.rotateAxisZ'))
 

--- a/maya/Tests/staticNurbsCurve_test.py
+++ b/maya/Tests/staticNurbsCurve_test.py
@@ -305,3 +305,31 @@ class StaticNurbsCurveTest(unittest.TestCase):
         # constant width check
         self.failUnless('width' in MayaCmds.listAttr('|group'))
         self.failUnlessAlmostEqual(MayaCmds.getAttr('|group.width'), 0.75, 4)
+
+    def testNurbsCurveGrpWidthRW3(self):
+
+        MayaCmds.curve(d=3, p=[(0, 0, 0), (3, 5, 0), (5, 6, 0), (9, 9, 0),
+            (12, 10, 0)], k=[0,0,0,1,2,2,2], name='curve1')
+        MayaCmds.select('curveShape1')
+        MayaCmds.addAttr('curveShape1', longName='width', attributeType='double', dv=1.5)
+
+        MayaCmds.curve(d=3, p=[(0, 0, 3), (3, 5, 3), (5, 6, 3), (9, 9, 3),
+            (12, 10, 3)], k=[0,0,0,1,2,2,2], name='curve2')
+        MayaCmds.addAttr('curveShape2', longName='width', attributeType='double', dv=3.0)
+
+        MayaCmds.curve(d=3, p=[(0, 0, 6), (3, 5, 6), (5, 6, 6), (9, 9, 6),
+            (12, 10, 6)], k=[0,0,0,1,2,2,2], name='curve3')
+        MayaCmds.select('curveShape3')
+        MayaCmds.addAttr('curveShape3', longName='width', attributeType='double', dv=4.5)
+
+        MayaCmds.group('curve1', 'curve2', 'curve3', name='group')
+        MayaCmds.addAttr('group', longName='riCurves', at='bool', dv=True)
+
+        self.__files.append(util.expandFileName('testStaticNurbsCurveGrpWidthTest3.abc'))
+        MayaCmds.AbcExport(j='-root group -file ' + self.__files[-1])
+        MayaCmds.AbcImport(self.__files[-1], mode='open')
+
+        # constant width check
+        self.failUnlessAlmostEqual(MayaCmds.getAttr('|group|group.width'),  1.5, 4)
+        self.failUnlessAlmostEqual(MayaCmds.getAttr('|group|group1.width'), 3.0, 4)
+        self.failUnlessAlmostEqual(MayaCmds.getAttr('|group|group2.width'), 4.5, 4)


### PR DESCRIPTION
Currently only constant and per vertex widths are supported.