### PR TITLE
AbcExport sparse transform improvements

### DIFF
--- a/lib/Alembic/AbcGeom/OXform.h
+++ b/lib/Alembic/AbcGeom/OXform.h
@@ -165,7 +165,7 @@ public:
     //! Valid returns whether this function set is valid.
     bool valid() const
     {
-        return ( m_opsPWPtr && super_type::valid() );
+        return ( super_type::valid() );
     }
 
     //! unspecified-bool-type operator overload.

--- a/lib/Alembic/AbcGeom/Tests/XformTests2.cpp
+++ b/lib/Alembic/AbcGeom/Tests/XformTests2.cpp
@@ -46,6 +46,7 @@ void xformOut()
     OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), "matrixXform.abc" );
     OXform a( OObject( archive, kTop ), "a" );
 
+    TESTING_ASSERT( a.getSchema().valid() );
 
     M44d mat;
     mat.makeIdentity();
@@ -62,7 +63,11 @@ void xformOut()
 
         a.getSchema().set( asamp );
     }
+    TESTING_ASSERT( a.getSchema().valid() );
 
+    OXform b;
+    TESTING_ASSERT( !b.valid() );
+    TESTING_ASSERT( !b.getSchema().valid() );
 }
 
 //-*****************************************************************************

--- a/maya/AbcExport/AttributesWriter.cpp
+++ b/maya/AbcExport/AttributesWriter.cpp
@@ -1699,7 +1699,7 @@ bool isPerParticleAttributes( const MFnDependencyNode &iNode, MObject attrObj )
 {
     MStatus status(MS::kSuccess);
 
-    if ( !iNode.hasObj(MFn::kParticle))
+    if ( !iNode.object().hasFn(MFn::kParticle))
     {
         return false;
     }
@@ -2177,7 +2177,7 @@ bool AttributesWriter::hasAnyAttr(const MFnDependencyNode & iNode,
 
     std::vector< PlugAndObjArray > staticPlugObjArrayVec;
 
-    if (iNode.hasObj(MFn::kParticle))
+    if (iNode.object().hasFn(MFn::kParticle))
     {
         // Particles always have extra attributes
         return true;

--- a/maya/AbcExport/MayaPointPrimitiveWriter.cpp
+++ b/maya/AbcExport/MayaPointPrimitiveWriter.cpp
@@ -173,7 +173,7 @@ void MayaPointPrimitiveWriter::write(double iFrame)
     {
         // Get the value of the radius attribute
         widthScope = AbcGeom::kUniformScope;
-        width.push_back( particle.findPlug("radius").asDouble() );
+        width.push_back( particle.findPlug("radius", true).asDouble() );
     }
 
 

--- a/maya/AbcExport/MayaTransformWriter.h
+++ b/maya/AbcExport/MayaTransformWriter.h
@@ -72,12 +72,14 @@ class MayaTransformWriter
     ~MayaTransformWriter();
     void write();
     bool isAnimated() const;
-    Alembic::Abc::OObject getObject() {return mSchema.getObject();};
+    Alembic::Abc::OObject getObject();
     AttributesWriterPtr getAttrs() {return mAttrs;};
 
   private:
 
     Alembic::AbcGeom::OXformSchema mSchema;
+    Alembic::AbcGeom::OObject mObject;
+
     AttributesWriterPtr mAttrs;
 
     void pushTransformStack(const MFnTransform & iTrans, bool iForceStatic);


### PR DESCRIPTION
When writing the sparse data via AbcExport, don't create the hierarchy via

OXform, instead just create the OObject.

arbGeomParams and userProperties were being created when there were no attrs
to write out because hasObj(MFn::kParticle) was always returning true.

Get rid of a deprecated warning in MayaPointPrimitiveWriter.

OXformSchema::valid had to have ops to return true.