### PR TITLE
Change the optional DCC fps from a uint32_t to a double

### DIFF
--- a/bin/AbcLs/AbcLs.cpp
+++ b/bin/AbcLs/AbcLs.cpp
@@ -752,7 +752,7 @@ int main( int argc, char *argv[] )
             std::string whenWritten;
             std::string userDescription;
             std::string coreName;
-            Alembic::Util::uint32_t dccFps;
+            double dccFps;
             GetArchiveInfo (archive,
                             appName,
                             libraryVersionString,

--- a/lib/Alembic/Abc/ArchiveInfo.cpp
+++ b/lib/Alembic/Abc/ArchiveInfo.cpp
@@ -49,7 +49,7 @@ GetArchiveInfo(
     Util::uint32_t & oAlembicApiVersion,
     std::string & oDateWritten,
     std::string & oUserDescription,
-    Util::uint32_t & oDCCFPS)
+    double & oDCCFPS)
 {
     if ( ! iArchive.getPtr() )
     {
@@ -63,7 +63,7 @@ GetArchiveInfo(
 
     oDateWritten = md.get( kDateWrittenKey );
     oUserDescription = md.get( kUserDescriptionKey );
-    oDCCFPS = ( Util::uint32_t ) atoi( md.get( kDCCFPSKey ).c_str() );
+    oDCCFPS = atof( md.get( kDCCFPSKey ).c_str() );
 }
 
 void
@@ -75,7 +75,7 @@ GetArchiveInfo(
     std::string & oDateWritten,
     std::string & oUserDescription)
 {
-    Util::uint32_t unusedFps;
+    double unusedFps;
     GetArchiveInfo( iArchive, oApplicationWriter, oAlembicVersion,
         oAlembicApiVersion, oDateWritten, oUserDescription, unusedFps );
 }

--- a/lib/Alembic/Abc/ArchiveInfo.h
+++ b/lib/Alembic/Abc/ArchiveInfo.h
@@ -95,7 +95,7 @@ OArchive CreateArchiveWithInfo(
     const std::string &iFileName,
 
     //! Optional FPS hint that the DCC used at write time
-    Util::uint32_t iDCCFPS,
+    double iDCCFPS,
 
     //! Application specific information about what is writing the file
     const std::string & iApplicationWriter,
@@ -154,7 +154,7 @@ GetArchiveInfo(
 
     //! Optional hint about what FPS was being used by the DCC when this archive
     //! was created.
-    Util::uint32_t & oDCCFPS);
+    double & oDCCFPS);
 
 //-*****************************************************************************
 //! Convenience function which gets a start and end time for the archive using
@@ -177,7 +177,7 @@ template <class ARCHIVE_CTOR>
 OArchive CreateArchiveWithInfo(
     ARCHIVE_CTOR iCtor,
     const std::string &iFileName,
-    Util::uint32_t iDCCFPS,
+    double iDCCFPS,
     const std::string &iApplicationWriter,
     const std::string &iUserDescription,
     const Argument &iArg0,
@@ -212,7 +212,7 @@ OArchive CreateArchiveWithInfo(
         md.set( kUserDescriptionKey, iUserDescription );
     }
 
-    if ( iDCCFPS > 0 )
+    if ( iDCCFPS > 0.0 )
     {
         md.set( kDCCFPSKey, std::to_string( iDCCFPS ) );
     }

--- a/lib/Alembic/Abc/Tests/ArchiveTest.cpp
+++ b/lib/Alembic/Abc/Tests/ArchiveTest.cpp
@@ -115,7 +115,7 @@ void archiveInfoTest(bool useOgawa)
 
         // test it again but the DCC FPS variant, pass in a bogus value
         // to show that it gets reset to 0 when it doesn't exist
-        Alembic::Util::uint32_t dcc_fps = 123;
+        double dcc_fps = 123;
         GetArchiveInfo( archive, appInfo, abcVersionStr, abcVersion,
             dateWritten, userInfo, dcc_fps);
         TESTING_ASSERT( appWriter ==  appInfo );
@@ -148,7 +148,7 @@ void archiveInfoTest(bool useOgawa)
         std::string appInfo;
         std::string abcVersionStr;
         Alembic::Util::uint32_t abcVersion = 0;
-        Alembic::Util::uint32_t dcc_fps = 123;
+        double dcc_fps = 123.0;
         std::string dateWritten;
         std::string userInfo;
         GetArchiveInfo( archive, appInfo, abcVersionStr, abcVersion,
@@ -160,7 +160,7 @@ void archiveInfoTest(bool useOgawa)
         std::cout << "Date written: " << dateWritten << std::endl;
         TESTING_ASSERT( dateWritten != "" );
         TESTING_ASSERT( abcVersionStr != "" );
-        TESTING_ASSERT( dcc_fps == 42 );
+        TESTING_ASSERT( dcc_fps == 42.0 );
 
         double start, end;
         GetArchiveStartAndEndTime( archive, start, end );

--- a/maya/AbcExport/AbcWriteJob.cpp
+++ b/maya/AbcExport/AbcWriteJob.cpp
@@ -835,7 +835,7 @@ bool AbcWriteJob::eval(double iFrame)
         }
 
         MTime sec(1.0, MTime::kSeconds);
-        Alembic::Util::uint32_t fps(sec.as(MTime::uiUnit()));
+        double fps(sec.as(MTime::uiUnit()));
 
 #ifdef ALEMBIC_WITH_HDF5
         if (mAsOgawa)

--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -382,17 +382,17 @@ MStatus AlembicNode::initialize()
 
 double AlembicNode::getFPS()
 {
-    float fps = 24.0f;
+    double fps = 24.0f;
     MTime::Unit unit = MTime::uiUnit();
     if (unit!=MTime::kInvalid)
     {
         MTime time(1.0, MTime::kSeconds);
-        fps = static_cast<float>(time.as(unit));
+        fps = time.as(unit);
     }
 
-    if (fps <= 0.f )
+    if (fps <= 0.0 )
     {
-        fps = 24.0f;
+        fps = 24.0;
     }
 
     return fps;


### PR DESCRIPTION
This was to accommodate certain setting that I had not previously anticipated.