### PR TITLE
Fix incompatible data types issue when importing a Alembic::Util::kFloat32POD attribute

### DIFF
--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -323,6 +323,7 @@ MStatus AlembicNode::initialize()
     status = gAttr.addDataAccept(MFnData::kString);
     status = gAttr.addDataAccept(MFnData::kIntArray);
     status = gAttr.addDataAccept(MFnData::kDoubleArray);
+    status = gAttr.addDataAccept(MFnData::kFloatArray);
     status = gAttr.addDataAccept(MFnData::kVectorArray);
     status = gAttr.addDataAccept(MFnData::kPointArray);
 


### PR DESCRIPTION
Add kFloatArray to the accepted data types so a connection can be made for a 'Alembic::Util::kFloat32POD' data type.

When connecting attributes, the destination plug is expecting a kFloatArray but it's not one of the accepted types in the source plug.