### PR TITLE
Adds support for float arrays in Maya

### DIFF
--- a/maya/AbcImport/AlembicNode.cpp
+++ b/maya/AbcImport/AlembicNode.cpp
@@ -323,6 +323,7 @@ MStatus AlembicNode::initialize()
     status = gAttr.addDataAccept(MFnData::kString);
     status = gAttr.addDataAccept(MFnData::kIntArray);
     status = gAttr.addDataAccept(MFnData::kDoubleArray);
+    status = gAttr.addDataAccept(MFnData::kFloatArray);
     status = gAttr.addDataAccept(MFnData::kVectorArray);
     status = gAttr.addDataAccept(MFnData::kPointArray);
 


### PR DESCRIPTION
Note: This replaces #248.

Minor change - Adds kFloatArray to the accepted data types so a maya connection can be made for a 'Alembic::Util::kFloat32POD' data type. 