### PR TITLE
Fix uninitialized member variable in class OTypedGeomParam.

### DIFF
--- a/lib/Alembic/AbcGeom/OGeomParam.h
+++ b/lib/Alembic/AbcGeom/OGeomParam.h
@@ -141,7 +141,11 @@ public:
 
     }
 
-    OTypedGeomParam() {}
+    OTypedGeomParam()
+    : m_scope(kUnknownScope)
+    , m_isIndexed(false)
+    {
+    }
 
     OTypedGeomParam( OCompoundProperty iParent,
                      const std::string &iName,


### PR DESCRIPTION
The default constructor in OTypedGeomParam does not initialize its
member variables. This can lead to undefined behavior when, at a later
point, e.g. the copy-assignment operator is called. This commit fixes
this issue by initializing the non-class member variables on
OTypedGeomParam.

Note, at Autodesk we discovered this bug when we ran Alembic under
clang address sanitizers:

    116: /path/to/alembic-1.7.5/include/Alembic/AbcGeom/OGeomParam.h:49:7: runtime error: load of value 4, which is not a valid value for type 'bool'
    116:     #0 0x7f7fcf6cc34c in Alembic::AbcGeom::v10::OTypedGeomParam<Alembic::Abc::v10::V2fTPTraits>::operator=(Alembic::AbcGeom::v10::OTypedGeomParam<Alembic::Abc::v10::V2fTPTraits> const&) 
    116:     #1 0x7f7fcf6ce9c5 in Alembic::AbcGeom::v10::OPolyMeshSchema::operator=(Alembic::AbcGeom::v10::OPolyMeshSchema const&) 
    116:     #2 0x7f7fcf6e5a7b in Alembic::Abc::v10::OSchemaObject<Alembic::AbcGeom::v10::OPolyMeshSchema>::OSchemaObject(Alembic::Abc::v10::OObject, std::string const&, Alembic::Abc::v10::Argument const&, Alembic::Abc::v10::Argument const&, Alembic::Abc::v10::Argument const&) /path/to/alembic/1.7.5/8932ea0/alembic-1.7.5/include/Alembic/Abc/OSchemaObject.h:226