### PR TITLE
Add Python binding for Abc::GetArchiveStartAndEndTime

### DIFF
--- a/python/PyAlembic/PyArchiveInfo.cpp
+++ b/python/PyAlembic/PyArchiveInfo.cpp
@@ -101,6 +101,16 @@ static dict GetArchiveInfoWrapper( Abc::IArchive& iArchive )
 }
 
 //-*****************************************************************************
+static tuple GetArchiveStartAndEndTimeWrapper( Abc::IArchive& iArchive )
+{
+    double oStart;
+    double oEnd;
+    Abc::GetArchiveStartAndEndTime( iArchive, oStart, oEnd );
+
+    return make_tuple( oStart, oEnd );
+}
+
+//-*****************************************************************************
 void register_archiveinfo()
 {
     def( "CreateArchiveWithInfo",
@@ -113,6 +123,11 @@ void register_archiveinfo()
          GetArchiveInfoWrapper,
          ( arg( "IArchive" ) ),
          "Return a dictionary that contains info of the given IArchive" );
+    def( "GetArchiveStartAndEndTime",
+         GetArchiveStartAndEndTimeWrapper,
+         ( arg( "IArchive" ) ),
+         "Return tuple of start and end time for the IArchive using only the "
+         "TimeSamplings" );
 
     def( "GetLibraryVersionShort",
          AbcA::GetLibraryVersionShort,


### PR DESCRIPTION
ArchiveInfo's Abc::GetArchiveStartAndEndTime is a handy function to have available. I was in the process of implementing similar functionality in Python when I discovered it already existed on the C++ side.

I opted to return a tuple of the start and end time instead of a dict (similar to GetArchiveInfo), because I felt it was quite clear what the tuple represented based on the function name.
