### PR TITLE
Python Bindings: Add optional dccFPS to the Abc.GetArchiveInfo dict

### DIFF
--- a/python/PyAlembic/PyArchiveInfo.cpp
+++ b/python/PyAlembic/PyArchiveInfo.cpp
@@ -83,19 +83,25 @@ static dict GetArchiveInfoWrapper( Abc::IArchive& iArchive )
     AbcU::uint32_t libraryVersion;
     std::string whenWritten;
     std::string userDescription;
+    double dccFPS;
 
     Abc::GetArchiveInfo( iArchive,
                          appName,
                          libraryVersionString,
                          libraryVersion,
                          whenWritten,
-                         userDescription );
+                         userDescription,
+                         dccFPS );
     dict info;
     info["appName"] = appName;
     info["libraryVersionString"] = libraryVersionString;
     info["libraryVersion"] = libraryVersion;
     info["whenWritten"] = whenWritten;
     info["userDescription"] = userDescription;
+    if ( dccFPS > 0.0 )
+    {
+        info["dccFPS"] = dccFPS;
+    }
 
     return info;
 }


### PR DESCRIPTION
Small Python bindings change to get the optional `_ai_DCC_FPS` from an Alembic Archive via `Abc::GetArchiveInfo`.

While the API treats a FPS value of 0 as non-existent, I opted to only add the key/value to the GetArchiveInfo return dict if the value was > 0 to allow for more "Pythonic" code on the user side. Plus this makes it easier to support Alembic archives that do not have the FPS metadata.

```
has_fps = 'dccFPS' in GetArchiveInfo(archive)
```
vs
```
try:
  has_fps = GetArchiveInfo(archive)['dccFPS'] > 0
except KeyError:
  has_fps = False
```
  