### PR TITLE
Fix char signedness to signed char, since char on some architectures …

### DIFF
--- a/lib/Alembic/AbcCoreHDF5/StringReadUtil.cpp
+++ b/lib/Alembic/AbcCoreHDF5/StringReadUtil.cpp
@@ -47,13 +47,13 @@ template <class CharT>
 static inline hid_t GetNativeDtype();
 
 template <>
-inline hid_t GetNativeDtype<char>() { return H5T_NATIVE_CHAR; }
+inline hid_t GetNativeDtype<char>() { return H5T_NATIVE_SCHAR; }
 
 template <>
 inline hid_t GetNativeDtype<wchar_t>()
 {
     // return H5T_NATIVE_INT32;
-    if ( sizeof( wchar_t ) == 1 ) { return H5T_NATIVE_CHAR; }
+    if ( sizeof( wchar_t ) == 1 ) { return H5T_NATIVE_SCHAR; }
     else if ( sizeof( wchar_t ) == 2 ) { return H5T_NATIVE_INT16; }
     else
     {


### PR DESCRIPTION
…is by default unsigned

This fixes some tests which fail on architectures like ARM, because on some architectures char is by default unsigned unlike x86