### PR TITLE
Fix Python 2.7 wheel build 

### DIFF
--- a/.github/actions/build-manylinux/Dockerfile
+++ b/.github/actions/build-manylinux/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2010_x86_64:latest
+FROM quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5
 
 # Setup dev environment
 

--- a/.github/actions/build-manylinux/build_alembic.sh
+++ b/.github/actions/build-manylinux/build_alembic.sh
@@ -18,6 +18,7 @@ cd Python-2.7.18
 ./configure --enable-optimizations --enable-shared --enable-unicode=ucs4
 make altinstall
 cd ..
+exec $SHELL
 curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -o "get-pip.py"
 python2.7 get-pip.py
 python2.7 -m pip install numpy

--- a/.github/actions/build-manylinux/build_alembic.sh
+++ b/.github/actions/build-manylinux/build_alembic.sh
@@ -4,7 +4,7 @@
 set -e -x
 
 # Download dependencies from package server
-yum update -y && yum install -y wget cmake3 git zlib-devel curl openssl-devel
+yum update -y && yum install -y wget git zlib-devel curl openssl-devel #cmake3 
 
 # change into home dir
 cd /home/
@@ -18,7 +18,7 @@ cd Python-2.7.18
 ./configure --enable-optimizations --enable-shared --enable-unicode=ucs4
 make altinstall
 cd ..
-curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -o "get-pip.py"
 python2.7 get-pip.py
 python2.7 -m pip install numpy
 
@@ -45,6 +45,13 @@ cd pyilmbase-2.2.0
 PYTHON=/usr/local/bin/python2.7 ./configure 
 make -j 4 && make install
 cd .. && rm -rf pyilmbase-2.2.0 pyilmbase.2.2.0.tar.gz
+
+# Build cmake 3.20
+wget https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0.tar.gz
+tar -xzf cmake-3.20.0.tar.gz
+cd cmake-3.20.0.tar.gz
+./bootstrap
+make -j 4 && make install
 
 # Build Alembic
 cd /github/workspace/  # Default location of packages in docker action

--- a/.github/actions/build-manylinux/build_alembic.sh
+++ b/.github/actions/build-manylinux/build_alembic.sh
@@ -50,7 +50,7 @@ cd .. && rm -rf pyilmbase-2.2.0 pyilmbase.2.2.0.tar.gz
 # Build cmake 3.20
 wget https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0.tar.gz
 tar -xzf cmake-3.20.0.tar.gz
-cd cmake-3.20.0.tar.gz
+cd cmake-3.20.0
 ./bootstrap
 make -j 4 && make install
 

--- a/.github/actions/build-manylinux/build_alembic.sh
+++ b/.github/actions/build-manylinux/build_alembic.sh
@@ -18,7 +18,7 @@ cd Python-2.7.18
 ./configure --enable-optimizations --enable-shared --enable-unicode=ucs4
 make altinstall
 cd ..
-exec $SHELL
+$SHELL
 curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -o "get-pip.py"
 python2.7 get-pip.py
 python2.7 -m pip install numpy

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+#     branches: [ master ]
+  pull_request:
+#     branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Use the alembic build action of this repo
+      - uses: ./.github/actions/build-manylinux
+
+      # Upload wheel as artifact
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheel
+          path: dist/*-manylinux*.whl

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from distutils.version import LooseVersion
 
+cmake_command = 'cmake'
 
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
@@ -18,16 +19,23 @@ class CMakeExtension(Extension):
 
 class CMakeBuild(build_ext):
     def run(self):
+        global cmake_command
         try:
-            out = subprocess.check_output(['cmake', '--version'])
+            out = subprocess.check_output([cmake_command, '--version'])
+            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
+            if cmake_version < '3.0.0':
+                cmake_command = 'cmake3'
+                out = subprocess.check_output([cmake_command, '--version']) 
+                cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
+
         except OSError:
-            raise RuntimeError("CMake must be installed to build the following extensions: " +
+            raise RuntimeError("CMake3 must be installed to build the following extensions: " +
                                ", ".join(e.name for e in self.extensions))
 
         if platform.system() == "Windows":
-            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
             if cmake_version < '3.1.0':
                 raise RuntimeError("CMake >= 3.1.0 is required on Windows")
+
 
         for ext in self.extensions:
             self.build_extension(ext)
@@ -37,9 +45,12 @@ class CMakeBuild(build_ext):
         # required for auto-detection of auxiliary "native" libs
         if not extdir.endswith(os.path.sep):
             extdir += os.path.sep
+        
+        python_major = str(sys.version_info.major)
 
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+                      '-DPYTHON_EXECUTABLE=' + sys.executable,
+                      '-DPYALEMBIC_PYTHON_MAJOR=' + python_major]
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]
@@ -60,9 +71,9 @@ class CMakeBuild(build_ext):
             os.makedirs(self.build_temp)
         
         cmake_args += ['-DUSE_PYALEMBIC=On']
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
-	
+        subprocess.check_call([cmake_command, ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call([cmake_command, '--build', '.'] + build_args, cwd=self.build_temp)
+
         # Copy missing dependencies
         site_dir = "/usr/local/lib/python2.7/site-packages"
         missing_packages = ["iexmodule.la", "iexmodule.so", "imathmodule.la", "imathmodule.so", "imathnumpymodule.la", "imathnumpymodule.so"]


### PR DESCRIPTION
This PR addresses #334 . For now this only fixes the build based on python 2.7. The error with the old pipeline was caused by incompatible pip install url as well as a broken manylinux docker image. I only ran a random few of the python tests for the generated wheel in order to verify that nothing obvious is broken with the wheel.

It might be good to look into creating a base docker image for this build, as the new pipeline takes more than 30 minutes to complete, because now also CMake has to be built in order to satisfy the new minimum cmake requirement.

I can address all of these points in the coming weeks (in this PR) but wanted to set this PR first in order to fix the python 2.7 build.

EDIT: I also modified `setup.py` to work with different aliases for cmake as well as setting the python major version for the cmake config when called from `setup.py`. 