### PR TITLE
[cmake] fix for using alembic as 3rd party with IMath 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,9 @@
 ##
 ##-*****************************************************************************
 
-PROJECT(Alembic)
-
 CMAKE_MINIMUM_REQUIRED(VERSION 3.13)
+
+PROJECT(Alembic VERSION 1.8.0)
 
 MESSAGE(STATUS "CMAKE SYSTEM NAME: ${CMAKE_SYSTEM_NAME}")
 
@@ -47,15 +47,6 @@ ENDIF()
 IF (NOT DEFINED QUIET)
     SET(CMAKE_VERBOSE_MAKEFILE TRUE)
 ENDIF()
-
-# Declare the project version
-SET(PROJECT_VERSION_MAJOR "1")
-SET(PROJECT_VERSION_MINOR "8")
-SET(PROJECT_VERSION_PATCH "0")
-
-SET(PROJECT_VERSION
-     ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
-SET(VERSION ${PROJECT_VERSION})
 
 #-******************************************************************************
 # OPTIONS (set with -D<option>=<value>)
@@ -169,7 +160,7 @@ ENDIF()
 
 IF (DEFINED ENV{ALEMBIC_INSTALL_PREFIX})
     SET( CMAKE_INSTALL_PREFIX
-        $ENV{ALEMBIC_INSTALL_PREFIX}/alembic-${VERSION})
+        $ENV{ALEMBIC_INSTALL_PREFIX}/alembic-${PROJECT_VERSION})
 ENDIF()
 
 # Tell me what my install location would be

--- a/lib/Alembic/AlembicConfig.cmake.in
+++ b/lib/Alembic/AlembicConfig.cmake.in
@@ -1,4 +1,7 @@
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/AlembicTargets.cmake")
+include(CMakeFindDependencyMacro)
+# TODO whenever we loose the back-compatibility with IlmBase < 3, a REQUIRED needs to be added to find_dependency()
+find_dependency(IMath)
 
 SET(Alembic_HAS_HDF5 @USE_HDF5@)
 SET(Alembic_HAS_SHARED_LIBS @ALEMBIC_SHARED_LIBS@)

--- a/lib/Alembic/AlembicConfig.cmake.in
+++ b/lib/Alembic/AlembicConfig.cmake.in
@@ -1,7 +1,11 @@
-INCLUDE("${CMAKE_CURRENT_LIST_DIR}/AlembicTargets.cmake")
+@PACKAGE_INIT@
+
 include(CMakeFindDependencyMacro)
 # TODO whenever we loose the back-compatibility with IlmBase < 3, a REQUIRED needs to be added to find_dependency()
 find_dependency(IMath)
 
 SET(Alembic_HAS_HDF5 @USE_HDF5@)
 SET(Alembic_HAS_SHARED_LIBS @ALEMBIC_SHARED_LIBS@)
+
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/@alembic_targets_file@")
+check_required_components("@PROJECT_NAME@")

--- a/lib/Alembic/CMakeLists.txt
+++ b/lib/Alembic/CMakeLists.txt
@@ -89,12 +89,18 @@ INSTALL(TARGETS Alembic
 # PACKAGE EXPORTS
 #-******************************************************************************
 
-CONFIGURE_FILE(AlembicConfig.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/AlembicConfig.cmake"
-    @ONLY
-    )
+set(alembic_targets_file "${PROJECT_NAME}Targets.cmake")
+
+SET(ConfigPackageLocation lib/cmake/Alembic CACHE PATH
+        "Where to install the Alembic's cmake files")
 
 INCLUDE(CMakePackageConfigHelpers)
+
+configure_package_config_file(AlembicConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/AlembicConfig.cmake"
+     INSTALL_DESTINATION ${ConfigPackageLocation}
+     )
+
 WRITE_BASIC_PACKAGE_VERSION_FILE(
     "${CMAKE_CURRENT_BINARY_DIR}/AlembicConfigVersion.cmake"
     VERSION
@@ -106,13 +112,10 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
 EXPORT(TARGETS
     Alembic
     FILE
-    "${CMAKE_CURRENT_BINARY_DIR}/AlembicTargets.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${alembic_targets_file}"
     NAMESPACE
     Alembic::
     )
-
-SET(ConfigPackageLocation lib/cmake/Alembic CACHE PATH
-    "Where to install the Alembic's cmake files")
 
 INSTALL(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/AlembicConfig.cmake"
@@ -137,7 +140,7 @@ ENDIF()
 INSTALL(EXPORT
     AlembicTargets
     FILE
-    AlembicTargets.cmake
+    ${alembic_targets_file}
     NAMESPACE
     Alembic::
     DESTINATION


### PR DESCRIPTION
Hi @lamiller0 
it would be nice if you can include this fix in the upcoming release.

It fixes a problem when using Alembic as third party and in particulary if  Imath 3 is used.
Since they switched to the modern cmake with the target export, you need a `find_dependency()` in the AlembicConfig.cmake otherwise it won't be able to find the target. This is not an issue if you use the old version < 3 as the paths are embedded directly in alembic targets. (see an example of the errors here https://github.com/alicevision/qmlAlembic/issues/15 and https://github.com/alicevision/qmlAlembic/issues/5)
Whenever you decide to drop the old behaviour you should add a `REQUIRED` as I wrote in the file as comment.

Incidentally, I took the opportunity to clean the cmake code:

* since we are with cmake 3.13 we can benefit of the fact that declaring the VERSION inside `project()` all the `PROJECT_VERSION*`  variables are automatically generated and set by cmake (cf https://cmake.org/cmake/help/latest/command/project.html#options)

* I used `configure_package_config_file()` to generate the `AlembicConfig.cmake` from the file template, which is the standar way to do. This includes adding that `@PACKAGE_INIT@` in the template that generates some automatic boilerplate code used by cmake (cf https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#generating-a-package-configuration-file)