### PR TITLE
Fix `imath` cmake config name.

### DIFF
--- a/lib/Alembic/AlembicConfig.cmake.in
+++ b/lib/Alembic/AlembicConfig.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 # TODO whenever we loose the back-compatibility with IlmBase < 3, a REQUIRED needs to be added to find_dependency()
-find_dependency(IMath)
+find_dependency(Imath)
 
 SET(Alembic_HAS_HDF5 @USE_HDF5@)
 SET(Alembic_HAS_SHARED_LIBS @ALEMBIC_SHARED_LIBS@)


### PR DESCRIPTION
`imath` is named it's project `Imath` not `IMath`
Miss-capitalization cause error in `cmake:find_package(Alembic)`  complaining about `unable to find `IMathConfig.cmake` file.

Fix #341