### PR TITLE
Expand message check on a failing test in 32bit builds

### DIFF
--- a/lib/Alembic/AbcCoreOgawa/ArImpl.cpp
+++ b/lib/Alembic/AbcCoreOgawa/ArImpl.cpp
@@ -81,7 +81,7 @@ void ArImpl::init()
 {
     Ogawa::IGroupPtr group = m_archive.getGroup();
 
-    int version = -1;
+    Util::int32_t version = -1;
     std::size_t numChildren = group->getNumChildren();
 
     if ( numChildren > 5 && group->isChildData( 0 ) &&
@@ -104,7 +104,7 @@ void ArImpl::init()
         "Unsupported file version detected: " << version );
 
     // if it isn't there, something is wrong
-    int fileVersion = 0;
+    Util::int32_t fileVersion = 0;
 
     Ogawa::IDataPtr data = group->getData( 1, 0 );
     if ( data->getSize() == 4 )

--- a/lib/Alembic/AbcCoreOgawa/Tests/fuzzTest.cpp
+++ b/lib/Alembic/AbcCoreOgawa/Tests/fuzzTest.cpp
@@ -486,8 +486,12 @@ void testFuzzer25192(bool iUseMMap)
     }
     catch(const std::exception& e)
     {
-        std::string msg = "Ogawa IStreams::read failed.";
-        TESTING_ASSERT(msg == e.what());
+        // In Issue 346 it was reported that on 32 bit systems
+        // we got the second error message, for now guard
+        // against it as well
+        std::string msg = e.what();
+        TESTING_ASSERT(msg == "Ogawa IStreams::read failed." ||
+            msg == "Ogawa IData illegal size.");
         return;
     }
     TESTING_ASSERT(0);

--- a/lib/Alembic/Ogawa/IStreams.cpp
+++ b/lib/Alembic/Ogawa/IStreams.cpp
@@ -471,7 +471,7 @@ private:
 
     struct MappedRegion
     {
-        size_t len;
+        Alembic::Util::uint64_t len;
         void* p;
 
         MappedRegion() : len(0), p(NULL)
@@ -488,7 +488,7 @@ private:
             return p != NULL;
         }
 
-        void map(FileHandle iFile, size_t iLength)
+        void map(FileHandle iFile, Alembic::Util::uint64_t iLength)
         {
             close();
 


### PR DESCRIPTION
Try to address a test failure for issue 346 on 32 bit systems by being more explicit about a couple of ints in ArImpl.cpp, since this may not address the issue, also check for message reported by the user.