### PR TITLE
Fixes to make Alembic exported config work for OpenEXR 2.x or Imath 3.x

### DIFF
--- a/cmake/AlembicIlmBase.cmake
+++ b/cmake/AlembicIlmBase.cmake
@@ -39,10 +39,12 @@ FIND_PACKAGE(Imath)
 IF (Imath_FOUND)
     MESSAGE(STATUS "Found package Imath")
     SET(ALEMBIC_ILMBASE_LIBS Imath::Imath)
+    SET(ALEMBIC_USING_IMATH_3 ON)
 ELSE()
     MESSAGE(STATUS "Could not find Imath looking for IlmBase instead.")
     # What we really want to do is look for libs Imath and half
     FIND_PACKAGE(IlmBase)
+    SET(ALEMBIC_USING_IMATH_3 OFF)
 
     IF (ILMBASE_FOUND)
         SET(ALEMBIC_ILMBASE_FOUND 1 CACHE STRING "Set to 1 if IlmBase is found, 0 otherwise")

--- a/lib/Alembic/AlembicConfig.cmake.in
+++ b/lib/Alembic/AlembicConfig.cmake.in
@@ -2,7 +2,12 @@
 
 include(CMakeFindDependencyMacro)
 # TODO whenever we loose the back-compatibility with IlmBase < 3, a REQUIRED needs to be added to find_dependency()
-find_dependency(Imath)
+if (@ALEMBIC_USING_IMATH_3@)
+    find_dependency(Imath)
+else ()
+    # Compatibility with OpenEXR 2.x, prior to Imath 3.x
+    find_dependency(IlmBase)
+endif ()
 
 SET(Alembic_HAS_HDF5 @USE_HDF5@)
 SET(Alembic_HAS_SHARED_LIBS @ALEMBIC_SHARED_LIBS@)


### PR DESCRIPTION
I believe the way it currently was, the exported AlembicConfig.cmake
was fine for if Imath3 is being used, but for building against older
OpenEXR 2.x, would not work properly.

The change: AlembicIlmBase.cmake sets a variable that reveals whether
Imath3 was found or if we fall back to useing OpenEXR 2.x. Then we use
that to alter what the exported Alembic.config.cmake ought to say in
terms of whether to find_dependency(Imath) or find_dependency(IlmBase).

This extra smidge of complexity can be removed when Imath 3.x is the
true minimum. But given that OpenEXR 2.4 is (unwisely, IMHO) the
choice for VFX Platform 2021 and in the current set of DCC versions, I
believe we need to support OpenEXR 2.4 as a first class citizen for
just a little bit longer.

Signed-off-by: Larry Gritz <lg@larrygritz.com>