### PR TITLE
Use _BitScanForward64 for ffsll with MSVC

### DIFF
--- a/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
+++ b/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
@@ -48,25 +48,6 @@ namespace ALEMBIC_VERSION_NS {
 // Windows
 #elif defined( _MSC_VER )
 #define COMPARE_EXCHANGE( V, COMP, EXCH ) (InterlockedCompareExchange64( &V, EXCH, COMP ) == COMP)
-
-Alembic::Util::int64_t ffsll( Alembic::Util::int64_t iValue )
-{
-    if ( !iValue )
-    {
-        return 0;
-    }
-
-    for ( Alembic::Util::int64_t bit = 0; bit < 64; ++bit )
-    {
-        if ( iValue & ( Alembic::Util::int64_t( 1 ) << bit ) )
-        {
-            return bit + 1;
-        }
-    }
-
-    return 0;
-}
-
 #elif defined( __HAIKU__ )
 
 #define COMPARE_EXCHANGE( V, COMP, EXCH ) __atomic_compare_exchange_n( &V, &COMP, EXCH, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST )
@@ -78,6 +59,15 @@ int ffsll(long long i)
 
 #else
 #error Please contact alembic-discuss@googlegroups.com for support.
+#endif
+
+#ifdef _MSC_VER
+Alembic::Util::int64_t ffsll( Alembic::Util::int64_t iValue )
+{
+    unsigned long index = 0;
+    _BitScanForward64(&index, iValue);
+    return index;
+}
 #endif
 
 StreamManager::StreamManager( std::size_t iNumStreams )

--- a/lib/Alembic/AbcGeom/OXform.h
+++ b/lib/Alembic/AbcGeom/OXform.h
@@ -159,6 +159,9 @@ public:
         m_arbGeomParams.reset();
         m_userProperties.reset();
 
+        m_useArrayProp = false;
+        m_isIdentity = true;
+
         super_type::reset();
     }
 
@@ -182,7 +185,7 @@ private:
 
     // should we store are channel values in an ArrayProperty,
     // or in a ScalarProperty with some Dimension > 0 and < MAX_SCALAR_CHANS
-    bool m_useArrayProp;
+    bool m_useArrayProp{false};
 
     AbcA::DataType m_arrayValuesDataType;
     Alembic::Util::Dimensions m_arraySampleDimensions;
@@ -205,7 +208,7 @@ protected:
     // calls to set; see usage in OXformSchema::set()
     XformSample m_protoSample;
 
-    bool m_isIdentity;
+    bool m_isIdentity{true};
 
     Abc::OCompoundProperty m_arbGeomParams;
 


### PR DESCRIPTION
Try and address compile error found with Issue #358 , but use _BitScanForward64.
Also address some of the feedback in #357 .