### PR TITLE
Fix Windows 32 bit compile error in Issue 372

### DIFF
--- a/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
+++ b/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
@@ -62,12 +62,37 @@ int ffsll(long long i)
 #endif
 
 #ifdef _MSC_VER
+
+#ifdef _WIN64
 Alembic::Util::int64_t ffsll( Alembic::Util::int64_t iValue )
 {
     unsigned long index = 0;
     _BitScanForward64(&index, iValue);
     return index;
 }
+#else
+Alembic::Util::int64_t ffsll( Alembic::Util::int64_t iValue )
+{
+    unsigned long index = 0;
+
+    // check the bottom 4 bytes
+    _BitScanForward(&index, iValue & 0xffffffff);
+    if ( index > 0 )
+    {
+        return index;
+    }
+
+    // now the top 4
+    _BitScanForward(&index, iValue >> 32);
+    if ( index > 0 )
+    {
+        // + 32 because this is the top 4 bytes, bottom 4 is 0
+        return index + 32;
+    }
+
+    return index;
+}
+#endif
 #endif
 
 StreamManager::StreamManager( std::size_t iNumStreams )

--- a/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
+++ b/lib/Alembic/AbcCoreOgawa/StreamManager.cpp
@@ -74,16 +74,17 @@ Alembic::Util::int64_t ffsll( Alembic::Util::int64_t iValue )
 Alembic::Util::int64_t ffsll( Alembic::Util::int64_t iValue )
 {
     unsigned long index = 0;
+    Alembic::Util::uint64_t value(iValue);
 
     // check the bottom 4 bytes
-    _BitScanForward(&index, iValue & 0xffffffff);
+    _BitScanForward(&index, value & 0xffffffff);
     if ( index > 0 )
     {
         return index;
     }
 
     // now the top 4
-    _BitScanForward(&index, iValue >> 32);
+    _BitScanForward(&index, value >> 32);
     if ( index > 0 )
     {
         // + 32 because this is the top 4 bytes, bottom 4 is 0


### PR DESCRIPTION
_BitScanForward64 is only available when _WIN64 is defined.
When it is not fall back to calling _BitScanForward twice.

Addresses #372 