### PR TITLE
fix include dirs for AbcCoreHDF5 tests

### DIFF
--- a/lib/Alembic/AbcCoreHDF5/Tests/CMakeLists.txt
+++ b/lib/Alembic/AbcCoreHDF5/Tests/CMakeLists.txt
@@ -33,7 +33,7 @@
 ##
 ##-*****************************************************************************
 
-INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/lib ${PROJECT_BINARY_DIR}/lib)
+INCLUDE_DIRECTORIES(${HDF5_INCLUDE_DIRS})
 
 SET(CXX_FILES
     ArchiveTests.cpp


### PR DESCRIPTION
I might be missing something obvious, but it seems like the tests for AbcCoreHDF5 are broken - they don't add `${HDF5_INCLUDE_DIRS}` to their includes.

This attempts to fix this - it also removes the adding of some lib dirs (?) to the include dirs.

Without this fix, I would get errors like this when building:

```
/src/NVIDIA/alembic-build/alembic/lib/Alembic/AbcCoreHDF5/Tests/ArrayPropertyTests.cpp:46:10: fatal error: hdf5.h: No such file or directory
   46 | #include <hdf5.h>
      |          ^~~~~~~~
```