### PR TITLE
Register the N2 Properties to the correct name

### DIFF
--- a/python/PyAlembic/PyITypedArrayProperty.cpp
+++ b/python/PyAlembic/PyITypedArrayProperty.cpp
@@ -160,8 +160,8 @@ void register_itypedarrayproperty()
     register_<Abc::IC4fArrayProperty>( "IC4fArrayProperty" );
     register_<Abc::IC4cArrayProperty>( "IC4cArrayProperty" );
 
-    register_<Abc::IN2fArrayProperty>( "IN3fArrayProperty" );
-    register_<Abc::IN2dArrayProperty>( "IN3dArrayProperty" );
+    register_<Abc::IN2fArrayProperty>( "IN2fArrayProperty" );
+    register_<Abc::IN2dArrayProperty>( "IN2dArrayProperty" );
 
     register_<Abc::IN3fArrayProperty>( "IN3fArrayProperty" );
     register_<Abc::IN3dArrayProperty>( "IN3dArrayProperty" );

--- a/python/PyAlembic/PyITypedScalarProperty.cpp
+++ b/python/PyAlembic/PyITypedScalarProperty.cpp
@@ -158,8 +158,8 @@ void register_itypedscalarproperty()
     register_<Abc::IC4fProperty>( "IC4fProperty" );
     register_<Abc::IC4cProperty>( "IC4cProperty" );
 
-    register_<Abc::IN2fProperty>( "IN3fProperty" );
-    register_<Abc::IN2dProperty>( "IN3dProperty" );
+    register_<Abc::IN2fProperty>( "IN2fProperty" );
+    register_<Abc::IN2dProperty>( "IN2dProperty" );
 
     register_<Abc::IN3fProperty>( "IN3fProperty" );
     register_<Abc::IN3dProperty>( "IN3dProperty" );

--- a/python/PyAlembic/PyOTypedArrayProperty.cpp
+++ b/python/PyAlembic/PyOTypedArrayProperty.cpp
@@ -161,8 +161,8 @@ void register_otypedarrayproperty()
     register_<Abc::OC4fArrayProperty>( "OC4fArrayProperty" );
     register_<Abc::OC4cArrayProperty>( "OC4cArrayProperty" );
 
-    register_<Abc::ON2fArrayProperty>( "ON3fArrayProperty" );
-    register_<Abc::ON2dArrayProperty>( "ON3dArrayProperty" );
+    register_<Abc::ON2fArrayProperty>( "ON2fArrayProperty" );
+    register_<Abc::ON2dArrayProperty>( "ON2dArrayProperty" );
 
     register_<Abc::ON3fArrayProperty>( "ON3fArrayProperty" );
     register_<Abc::ON3dArrayProperty>( "ON3dArrayProperty" );

--- a/python/PyAlembic/PyOTypedScalarProperty.cpp
+++ b/python/PyAlembic/PyOTypedScalarProperty.cpp
@@ -161,8 +161,8 @@ void register_otypedscalarproperty()
     register_<Abc::OC4fProperty>( "OC4fProperty" );
     register_<Abc::OC4cProperty>( "OC4cProperty" );
 
-    register_<Abc::ON2fProperty>( "ON3fProperty" );
-    register_<Abc::ON2dProperty>( "ON3dProperty" );
+    register_<Abc::ON2fProperty>( "ON2fProperty" );
+    register_<Abc::ON2dProperty>( "ON2dProperty" );
 
     register_<Abc::ON3fProperty>( "ON3fProperty" );
     register_<Abc::ON3dProperty>( "ON3dProperty" );


### PR DESCRIPTION
When porting some C++ code to Python I noticed that the alembic.Abc module was missing the various IN2\*Property and ON2\*Property classes.

This PR registers them to the correct name.

Example code:
```python
from imath import *
from alembic.Abc import *
from alembic.AbcGeom import *

def make():
    top = OArchive('cube.abc').getTop()
    xform_obj = OXform( top, 'cube1')
    xform = xform_obj.getSchema()
    props = xform.getUserProperties()
    n2f = ON2fProperty(props, 'n2f')
    n2f.setValue(V2f(1.0, 2.0))

def read():
    top = IArchive('cube.abc').getTop()
    props = top.getChild('cube1').getProperties()
    xform = props.getProperty('.xform')
    user = xform.getProperty('.userProperties')
    n2f = IN2fProperty(user, 'n2f')
    print(n2f.getValue(0))

make()
read()
```