### PR TITLE
Visual Studio 2017 front abort

### DIFF
--- a/lib/Alembic/AbcCoreOgawa/ReadUtil.cpp
+++ b/lib/Alembic/AbcCoreOgawa/ReadUtil.cpp
@@ -1494,8 +1494,9 @@ ReadTimeSamplesAndMax( Ogawa::IDataPtr iData,
         Util::uint32_t numSamples = DerefUnaligned<Util::uint32_t>(&buf[pos]);
         pos += 4;
 
-        // make sure our numSamples don't go beyond the buffer
-        if ( pos + sizeof( chrono_t ) * numSamples > bufSize)
+        // make sure our numSamples don't go beyond the buffer and that we
+        // have at least 1 of them
+        if ( numSamples < 1 || pos + sizeof( chrono_t ) * numSamples > bufSize)
         {
             ABCA_THROW("Read invalid: TimeSamples sample times.");
         }

--- a/lib/Alembic/AbcCoreOgawa/Tests/fuzzTest.cpp
+++ b/lib/Alembic/AbcCoreOgawa/Tests/fuzzTest.cpp
@@ -649,10 +649,8 @@ void testFuzzer52703(bool iUseMMap)
     }
     catch(const std::exception& e)
     {
-        std::string msg = "Invalid Time Sampling Type, time per cycle: ";
-        std::string msg2 = "Read invalid: TimeSamples sample times.";
-        std::string what = e.what();
-        TESTING_ASSERT(what.substr(0, msg.size()) == msg || what == msg2);
+        std::string msg = "Read invalid: TimeSamples sample times.";
+        TESTING_ASSERT(msg == e.what());
         return;
     }
 
@@ -720,10 +718,8 @@ void testFuzzerTaoTaoGu3699(bool iUseMMap)
     }
     catch(const std::exception& e)
     {
-        std::string msg = "Invalid Time Sampling Type, time per cycle:";
-        std::string msg2 = "Read invalid: TimeSamples sample times.";
-        std::string what = e.what();
-        TESTING_ASSERT(what.substr(0, msg.size()) == msg || what == msg2);
+        std::string msg = "Read invalid: TimeSamples sample times.";
+        TESTING_ASSERT(msg == e.what());
         return;
     }
 

--- a/lib/Alembic/AbcCoreOgawa/Tests/fuzzTest.cpp
+++ b/lib/Alembic/AbcCoreOgawa/Tests/fuzzTest.cpp
@@ -650,8 +650,9 @@ void testFuzzer52703(bool iUseMMap)
     catch(const std::exception& e)
     {
         std::string msg = "Invalid Time Sampling Type, time per cycle: ";
+        std::string msg2 = "Read invalid: TimeSamples sample times.";
         std::string what = e.what();
-        TESTING_ASSERT(what.substr(0, msg.size()) == msg);
+        TESTING_ASSERT(what.substr(0, msg.size()) == msg || what == msg2);
         return;
     }
 
@@ -720,8 +721,9 @@ void testFuzzerTaoTaoGu3699(bool iUseMMap)
     catch(const std::exception& e)
     {
         std::string msg = "Invalid Time Sampling Type, time per cycle:";
+        std::string msg2 = "Read invalid: TimeSamples sample times.";
         std::string what = e.what();
-        TESTING_ASSERT(what.substr(0, msg.size()) == msg);
+        TESTING_ASSERT(what.substr(0, msg.size()) == msg || what == msg2);
         return;
     }
 


### PR DESCRIPTION
While testing Windows, Visual Studio 2017 flagged a front call on an empty vector.  Fixed where this was happening and
needed to adjust a couple of our fuzzer test messages because of it.