### PR TITLE
Fix an issue with ALEMBIC_LIB_INSTALL_DIR

### DIFF
--- a/lib/Alembic/CMakeLists.txt
+++ b/lib/Alembic/CMakeLists.txt
@@ -78,7 +78,7 @@ TARGET_LINK_LIBRARIES(Alembic
     ${ZLIB_LIBRARY}
   )
 
-SET( ALEMBIC_LIB_INSTALL_DIR lib CACHE PATH "Where to install the Alembic libs")
+SET( ALEMBIC_LIB_INSTALL_DIR lib CACHE STRING "Where to install the Alembic libs")
 INSTALL(TARGETS Alembic
         EXPORT AlembicTargets
         LIBRARY DESTINATION ${ALEMBIC_LIB_INSTALL_DIR}


### PR DESCRIPTION
using PATH instead of STRING makes cmake create a path: https://cmake.org/cmake/help/latest/prop_cache/TYPE.html

eg `/path/to/build/bin` instead of juste `bin`

This fixes it.