### PR TITLE
Fix build failure using UNICODE

### DIFF
--- a/lib/Alembic/Ogawa/IStreams.cpp
+++ b/lib/Alembic/Ogawa/IStreams.cpp
@@ -445,7 +445,7 @@ private:
     {
         // Use both FILE_SHARE_READ and FILE_SHARE_WRITE as the share mode.
         // Without FILE_SHARE_WRITE, this will fail when trying to open a file that is already open for writing.
-        return CreateFile(iFileName.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        return CreateFileA(iFileName.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     }
 
     static void closeFile(FileHandle iFile)


### PR DESCRIPTION
I was trying to build this library via a vcpkg custom triplet, and discovered a build failure:

```
lib\Alembic\Ogawa\IStreams.cpp(448): error C2664: 'HANDLE CreateFileW(LPCWSTR,DWORD,DWORD,LPSECURITY_ATTRIBUTES,DWORD,DWORD,HANDLE)': cannot convert argument 1 from 'const _Elem *' to 'LPCWSTR'
        with
        [
            _Elem=char
        ]
```

My custom triplet uses ``_UNICODE`` and ``UNICODE`` which is standard for modern Windows apps--the uwp triplets do the same thing.

The problem is that the code is relying on legacy MBCS vs. UNICODE translation macros. Per the [UTF-8 Everywhere](https://utf8everywhere.org/) manifesto, you should always explicitly use ``CreateFileA`` or ``CreateFileW`` and not rely on the changing meaning of ``CreateFile``.

IOW: By explicitly using ``CreateFileA`` here, the library doesn't care about the build setting. Since it's always using a ``std::string``, it should always use ``CreateFileA``.