### PR TITLE
Make including Imath headers explicit.

### DIFF
--- a/arnold/Procedural/SampleUtil.cpp
+++ b/arnold/Procedural/SampleUtil.cpp
@@ -36,10 +36,10 @@
 #include "SampleUtil.h"
 
 #include <algorithm>
-#include <ImathMatrix.h>
-#include <ImathMatrixAlgo.h>
-#include <ImathQuat.h>
-#include <ImathEuler.h>
+#include <Imath/ImathMatrix.h>
+#include <Imath/ImathMatrixAlgo.h>
+#include <Imath/ImathQuat.h>
+#include <Imath/ImathEuler.h>
 
 //-*****************************************************************************
 void GetRelevantSampleTimes( ProcArgs &args, TimeSamplingPtr timeSampling,

--- a/bin/AbcEcho/AbcBoundsEcho.cpp
+++ b/bin/AbcEcho/AbcBoundsEcho.cpp
@@ -37,7 +37,7 @@
 #include <Alembic/AbcGeom/All.h>
 #include <Alembic/AbcCoreFactory/All.h>
 
-#include <ImathBoxAlgo.h>
+#include <Imath/ImathBoxAlgo.h>
 
 #include <iostream>
 

--- a/examples/AbcClients/WFObjConvert/Foundation.h
+++ b/examples/AbcClients/WFObjConvert/Foundation.h
@@ -40,7 +40,7 @@
 #include <Alembic/AbcGeom/All.h>
 #include <Alembic/Util/All.h>
 
-#include <ImathVec.h>
+#include <Imath/ImathVec.h>
 
 #include <boost/static_assert.hpp>
 #include <boost/scoped_ptr.hpp>

--- a/examples/AbcClients/WFObjConvert/ParseReader.h
+++ b/examples/AbcClients/WFObjConvert/ParseReader.h
@@ -40,7 +40,7 @@
 //-*****************************************************************************
 // Breaking my rules here about Foundation.h, to minimize recompiling
 // of the parser, which takes FOREVER. Stupid templates.
-#include <ImathVec.h>
+#include <Imath/ImathVec.h>
 #include <vector>
 #include <string>
 #include <set>

--- a/examples/AbcClients/WFObjConvert/Tests/parserTest.cpp
+++ b/examples/AbcClients/WFObjConvert/Tests/parserTest.cpp
@@ -34,7 +34,7 @@
 //
 //-*****************************************************************************
 
-#include <ImathVec.h>
+#include <Imath/ImathVec.h>
 #include <boost/config/warning_disable.hpp>
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>

--- a/lib/Alembic/Abc/Foundation.h
+++ b/lib/Alembic/Abc/Foundation.h
@@ -40,11 +40,11 @@
 #include <Alembic/AbcCoreAbstract/All.h>
 #include <Alembic/Util/All.h>
 
-#include <ImathVec.h>
-#include <ImathBox.h>
-#include <ImathMatrix.h>
-#include <ImathQuat.h>
-#include <ImathColor.h>
+#include <Imath/ImathVec.h>
+#include <Imath/ImathBox.h>
+#include <Imath/ImathMatrix.h>
+#include <Imath/ImathQuat.h>
+#include <Imath/ImathColor.h>
 
 #include <iostream>
 #include <string>

--- a/lib/Alembic/Abc/Tests/ObjectsAndPropertiesTest.cpp
+++ b/lib/Alembic/Abc/Tests/ObjectsAndPropertiesTest.cpp
@@ -39,7 +39,7 @@
 #include <Alembic/Abc/All.h>
 #include <Alembic/AbcCoreAbstract/Tests/Assert.h>
 
-#include <ImathMath.h>
+#include <Imath/ImathMath.h>
 
 #include <limits>
 

--- a/lib/Alembic/Abc/Tests/ParentingTest.cpp
+++ b/lib/Alembic/Abc/Tests/ParentingTest.cpp
@@ -43,7 +43,7 @@
 #include <Alembic/AbcCoreHDF5/All.h>
 #endif
 
-#include <ImathMath.h>
+#include <Imath/ImathMath.h>
 
 #include <limits>
 

--- a/lib/Alembic/Abc/Tests/TypedArraySampleTest.cpp
+++ b/lib/Alembic/Abc/Tests/TypedArraySampleTest.cpp
@@ -38,7 +38,7 @@
 #include <Alembic/AbcCoreOgawa/All.h>
 #include <Alembic/AbcCoreAbstract/Tests/Assert.h>
 
-#include <ImathMath.h>
+#include <Imath/ImathMath.h>
 
 #include <limits>
 

--- a/lib/Alembic/AbcCoreAbstract/Tests/Assert.h
+++ b/lib/Alembic/AbcCoreAbstract/Tests/Assert.h
@@ -46,7 +46,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include <ImathMath.h>
+#include <Imath/ImathMath.h>
 #include <limits>
 
 //-*****************************************************************************

--- a/lib/Alembic/AbcCoreAbstract/Tests/TestTimeSampling.cpp
+++ b/lib/Alembic/AbcCoreAbstract/Tests/TestTimeSampling.cpp
@@ -41,8 +41,8 @@
 #include <float.h>
 #include <stdlib.h>
 
-#include <ImathMath.h>
-#include <ImathRandom.h>
+#include <Imath/ImathMath.h>
+#include <Imath/ImathRandom.h>
 
 #include <vector>
 #include <iostream>

--- a/lib/Alembic/AbcCoreAbstract/TimeSampling.cpp
+++ b/lib/Alembic/AbcCoreAbstract/TimeSampling.cpp
@@ -38,7 +38,7 @@
 
 #include <Alembic/AbcCoreAbstract/DataType.h>
 
-#include <ImathMath.h>
+#include <Imath/ImathMath.h>
 
 #include <limits>
 

--- a/lib/Alembic/AbcCoreAbstract/TimeSamplingType.cpp
+++ b/lib/Alembic/AbcCoreAbstract/TimeSamplingType.cpp
@@ -36,7 +36,7 @@
 
 #include <Alembic/AbcCoreAbstract/TimeSamplingType.h>
 
-#include <ImathMath.h>
+#include <Imath/ImathMath.h>
 
 namespace Alembic {
 namespace AbcCoreAbstract {

--- a/lib/Alembic/AbcGeom/Foundation.h
+++ b/lib/Alembic/AbcGeom/Foundation.h
@@ -39,8 +39,8 @@
 
 #include <Alembic/Abc/All.h>
 
-#include <ImathMatrixAlgo.h>
-#include <ImathEuler.h>
+#include <Imath/ImathMatrixAlgo.h>
+#include <Imath/ImathEuler.h>
 
 
 namespace Alembic {

--- a/lib/Alembic/AbcGeom/Tests/PointsTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/PointsTest.cpp
@@ -36,7 +36,7 @@
 
 #include <Alembic/AbcGeom/All.h>
 #include <Alembic/AbcCoreOgawa/All.h>
-#include <ImathRandom.h>
+#include <Imath/ImathRandom.h>
 #include <Alembic/AbcCoreAbstract/Tests/Assert.h>
 
 namespace AbcG = Alembic::AbcGeom;

--- a/lib/Alembic/AbcGeom/XformSample.cpp
+++ b/lib/Alembic/AbcGeom/XformSample.cpp
@@ -37,9 +37,9 @@
 #include <Alembic/AbcGeom/XformSample.h>
 #include <Alembic/AbcGeom/XformOp.h>
 
-#include <ImathMatrix.h>
-#include <ImathMatrixAlgo.h>
-#include <ImathQuat.h>
+#include <Imath/ImathMatrix.h>
+#include <Imath/ImathMatrixAlgo.h>
+#include <Imath/ImathQuat.h>
 
 #include <math.h>
 #ifndef M_PI

--- a/lib/Alembic/Util/Foundation.h
+++ b/lib/Alembic/Util/Foundation.h
@@ -42,7 +42,7 @@
 
 #include <memory>
 
-#include <half.h>
+#include <Imath/half.h>
 
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
Hello,

I have a trouble that Imath headers are not found when building my app using vcpkg. This patch resolves my trouble, and I have only added "Imath/" to the head of Imath headers.
However, I'm not sure that "half.h" in lib/Alembic/Util/Foundation.h means "Imath/half.h".
If this is correct, could you please merge this patch?