### PR TITLE
fix default value of each Float(16|32|64)PODTraits.

### DIFF
--- a/lib/Alembic/Util/PlainOldDataType.h
+++ b/lib/Alembic/Util/PlainOldDataType.h
@@ -260,9 +260,9 @@ DECLARE_TRAITS( kUint32POD,  uint32_t,  "uint32_t",  0,     Uint32PODTraits );
 DECLARE_TRAITS( kInt32POD,   int32_t,   "int32_t",   0,     Int32PODTraits );
 DECLARE_TRAITS( kUint64POD,  uint64_t,  "uint64_t",  0,     Uint64PODTraits );
 DECLARE_TRAITS( kInt64POD,   int64_t,   "int64_t",   0,     Int64PODTraits );
-DECLARE_TRAITS( kFloat16POD, float16_t, "float16_t", 0,     Float16PODTraits );
-DECLARE_TRAITS( kFloat32POD, float32_t, "float32_t", 0,     Float32PODTraits );
-DECLARE_TRAITS( kFloat64POD, float64_t, "float64_t", 0,     Float64PODTraits );
+DECLARE_TRAITS( kFloat16POD, float16_t, "float16_t", 0.0f,  Float16PODTraits );
+DECLARE_TRAITS( kFloat32POD, float32_t, "float32_t", 0.0f,  Float32PODTraits );
+DECLARE_TRAITS( kFloat64POD, float64_t, "float64_t", 0.0,   Float64PODTraits );
 DECLARE_TRAITS( kStringPOD,  string,    "string",    "",    StringPODTraits );
 DECLARE_TRAITS( kWstringPOD, wstring,   "wstring",   L"",   WstringPODTraits );
 


### PR DESCRIPTION
Hello,

I fixed default value of each Float(16|32|64)PODTraits.

If CUDA is enabled, a type alias "half" represents one defined in CUDA. Its implementation only support conversion from float or double. I also check the implementation of half by Imath, which supports conversion from float.
So, I set the default value of Float16PODTrais to 0.0f.

reference:
cuda_fp16.hpp in CUDA 12.1 (line 214, 215)
[Imath/half.h](https://github.com/AcademySoftwareFoundation/Imath/blob/463677f4e3646de509447fed24c27c40846bf5bc/src/Imath/half.h#L509) (and the bottom)
[IlmBase/Half/half.h](https://github.com/AcademySoftwareFoundation/openexr/blob/3caf47dac47956750b9af4711862ef8acc569015/IlmBase/Half/half.h#L429)