### PR TITLE
Address issue 430 OSchema::setFromPrevious

### DIFF
--- a/lib/Alembic/AbcGeom/OCurves.cpp
+++ b/lib/Alembic/AbcGeom/OCurves.cpp
@@ -358,6 +358,7 @@ void OCurvesSchema::setFromPrevious()
     if ( m_ordersProperty ) { m_ordersProperty.setFromPrevious(); }
     if ( m_knotsProperty ) { m_knotsProperty.setFromPrevious(); }
 
+    m_numSamples++;
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 

--- a/lib/Alembic/AbcGeom/OLight.cpp
+++ b/lib/Alembic/AbcGeom/OLight.cpp
@@ -161,8 +161,8 @@ size_t OLightSchema::getNumSamples()
 {
     ALEMBIC_ABC_SAFE_CALL_BEGIN( "OLightSchema::getNumSamples" );
 
-    if ( m_childBoundsProperty )
-        return m_childBoundsProperty.getNumSamples();
+    if ( m_cameraSchema )
+        return m_cameraSchema.getNumSamples();
 
     ALEMBIC_ABC_SAFE_CALL_END();
 

--- a/lib/Alembic/AbcGeom/ONuPatch.cpp
+++ b/lib/Alembic/AbcGeom/ONuPatch.cpp
@@ -424,7 +424,7 @@ void ONuPatchSchema::createPositionProperties()
 
     // initialize any required properties
     m_positionsProperty = Abc::OP3fArrayProperty( _this, "P", mdata, m_timeSamplingIndex );
-    
+
     std::vector<V3f> emptyVec;
     const V3fArraySample empty( emptyVec );
     for ( size_t i = 0 ; i < m_numSamples ; ++i )
@@ -649,6 +649,7 @@ void ONuPatchSchema::setFromPrevious( )
         m_trimWProperty.setFromPrevious();
     }
 
+    m_numSamples++;
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 

--- a/lib/Alembic/AbcGeom/OPoints.cpp
+++ b/lib/Alembic/AbcGeom/OPoints.cpp
@@ -254,6 +254,8 @@ void OPointsSchema::setFromPrevious()
     if ( m_velocitiesProperty ) { m_velocitiesProperty.setFromPrevious(); }
     if ( m_widthsParam ) { m_widthsParam.setFromPrevious(); }
 
+    m_numSamples++;
+
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 
@@ -316,7 +318,7 @@ void OPointsSchema::createPositionProperty()
 {
     AbcA::MetaData mdata;
     SetGeometryScope( mdata, kVaryingScope );
-    
+
     m_positionsProperty = Abc::OP3fArrayProperty( this->getPtr(), "P", mdata, m_timeSamplingIndex );
 
     std::vector<V3f> emptyV3Vec;

--- a/lib/Alembic/AbcGeom/OPolyMesh.cpp
+++ b/lib/Alembic/AbcGeom/OPolyMesh.cpp
@@ -327,6 +327,7 @@ void OPolyMeshSchema::setFromPrevious()
     if ( m_uvsParam ) { m_uvsParam.setFromPrevious(); }
     if ( m_normalsParam ) { m_normalsParam.setFromPrevious(); }
 
+    m_numSamples++;
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 

--- a/lib/Alembic/AbcGeom/OSubD.cpp
+++ b/lib/Alembic/AbcGeom/OSubD.cpp
@@ -575,6 +575,8 @@ void OSubDSchema::setFromPrevious()
 
     if ( m_uvsParam ) { m_uvsParam.setFromPrevious(); }
 
+    m_numSamples++;
+
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 

--- a/lib/Alembic/AbcGeom/Tests/CameraTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/CameraTest.cpp
@@ -64,6 +64,9 @@ void cameraTest()
         samp.setHorizontalAperture( 4.8 );
         samp.setVerticalFilmOffset( 3.0 );
         camSchema.set( samp );
+        camSchema.setFromPrevious();
+        camSchema.setFromPrevious();
+        TESTING_ASSERT( camSchema.getNumSamples() == 4 );
     }
 
     {
@@ -100,7 +103,7 @@ void cameraTest()
         TESTING_ASSERT( samp.getNumOpChannels() == 0 );
         TESTING_ASSERT( samp.getFilmBackMatrix() == identity );
 
-        TESTING_ASSERT( cam.getSchema().getNumSamples() == 2 );
+        TESTING_ASSERT( cam.getSchema().getNumSamples() == 4 );
 
         cam.getSchema().get( samp );
         TESTING_ASSERT( almostEqual( samp.getFocalLength(), 35.0 ) );

--- a/lib/Alembic/AbcGeom/Tests/CurvesTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/CurvesTest.cpp
@@ -91,8 +91,10 @@ void Example1_CurvesOut()
     for ( size_t i = 0 ; i < 5 ; ++i )
     {
         doSample( myCurves );
+        myCurves.getSchema().setFromPrevious();
     }
 
+    TESTING_ASSERT( myCurves.getSchema().getNumSamples() == 10 );
     // Alembic objects close themselves automatically when they go out
     // of scope. So - we don't have to do anything to finish
     // them off!

--- a/lib/Alembic/AbcGeom/Tests/LightTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/LightTest.cpp
@@ -57,6 +57,9 @@ void lightTest()
         samp.setChildBounds( Abc::Box3d(
             Abc::V3d( 0.0, 0.1, 0.2), Abc::V3d( 0.3, 0.4, 0.5 ) ) );
         lightObj.getSchema().setCameraSample( samp );
+        lightObj.getSchema().setFromPrevious();
+        lightObj.getSchema().setFromPrevious();
+        TESTING_ASSERT( lightObj.getSchema().getNumSamples() == 4 );
 
         Abc::OCompoundProperty arb = lightObj.getSchema().getArbGeomParams();
         OFloatGeomParam param(arb, "test", false,
@@ -80,6 +83,7 @@ void lightTest()
             lightObj.getSchema().getArbGeomParams().getNumProperties() == 1 );
         TESTING_ASSERT(
             lightObj.getSchema().getUserProperties().getNumProperties() == 1 );
+        TESTING_ASSERT( lightObj.getSchema().getNumSamples() == 4 );
 
         lightObj.getSchema().getCameraSchema().get( samp, 0 );
         samp.getScreenWindow( top, bottom, left, right );

--- a/lib/Alembic/AbcGeom/Tests/NurbsTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/NurbsTest.cpp
@@ -119,6 +119,11 @@ void Example1_NurbsOut()
     // Set the sample.
     myNurbsSchema.set( nurbsSample );
 
+    myNurbsSchema.setFromPrevious();
+    myNurbsSchema.setFromPrevious();
+
+    TESTING_ASSERT( myNurbsSchema.getNumSamples() == 3 );
+
     // Alembic objects close themselves automatically when they go out
     // of scope. So - we don't have to do anything to finish
     // them off!
@@ -381,7 +386,7 @@ void SparseTest()
     std::string name = "sparseNurbsTest.abc";
     {
         OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), name );
-        
+
         // only set normals
         ONuPatch nurbsNormalsObj( OObject( archive, kTop ), "nurbsNormals", kSparse );
         ONuPatchSchema::Sample nurbsSamp;

--- a/lib/Alembic/AbcGeom/Tests/PointsTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/PointsTest.cpp
@@ -463,6 +463,10 @@ void optPropTest()
         samp.setVelocities( V3fArraySample() );
         samp.setWidths( OFloatGeomParam::Sample() );
         pt.set( samp );
+        pt.setFromPrevious();
+        pt.setFromPrevious();
+        pt.setFromPrevious();
+        TESTING_ASSERT( 10 == pt.getNumSamples() );
     }
 
     {
@@ -470,8 +474,8 @@ void optPropTest()
 
         IPoints ptsObj( IObject( archive, kTop ), "pts" );
         IPointsSchema &pts = ptsObj.getSchema();
-        TESTING_ASSERT( 7 == pts.getNumSamples() );
-        TESTING_ASSERT( 7 == pts.getVelocitiesProperty().getNumSamples() );
+        TESTING_ASSERT( 10 == pts.getNumSamples() );
+        TESTING_ASSERT( 10 == pts.getVelocitiesProperty().getNumSamples() );
     }
 }
 

--- a/lib/Alembic/AbcGeom/Tests/PolyMeshTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/PolyMeshTest.cpp
@@ -148,9 +148,16 @@ void Example1_MeshOut()
     mesh.set( mesh_samp );
     mesh.set( mesh_samp );
 
-    // do it twice to make sure getChildBoundsProperty works correctly
+    // set form previous twice
+    mesh.setFromPrevious();
+    mesh.setFromPrevious();
+
+    // do it 4 sets to make sure getChildBoundsProperty lines up with what
+    // we set for samples
     mesh.getChildBoundsProperty().set( cbox );
     mesh.getChildBoundsProperty().set( cbox );
+    mesh.getChildBoundsProperty().setFromPrevious();
+    mesh.getChildBoundsProperty().setFromPrevious();
 
     // Alembic objects close themselves automatically when they go out
     // of scope. So - we don't have to do anything to finish

--- a/lib/Alembic/AbcGeom/Tests/SubDTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/SubDTest.cpp
@@ -116,6 +116,11 @@ void Example1_MeshOut()
     mesh_samp.setInterpolateBoundary( 0 );
     mesh.set( mesh_samp );
 
+    mesh.setFromPrevious();
+    mesh.setFromPrevious();
+
+    TESTING_ASSERT( mesh.getNumSamples() == 5 );
+
     C3f color_val( 1.0, 0.0, 0.0 );
 
     OCompoundProperty arbParams = mesh.getArbGeomParams();
@@ -177,7 +182,7 @@ void Example1_MeshIn()
         mesh.getInterpolateBoundaryProperty().getErrorHandlerPolicy() ==
         ErrorHandler::kNoisyNoopPolicy );
 
-    TESTING_ASSERT( 3 == mesh.getNumSamples() );
+    TESTING_ASSERT( 5 == mesh.getNumSamples() );
 
     // UVs
     IV2fGeomParam uv = mesh.getUVsParam();

--- a/lib/Alembic/AbcGeom/Tests/XformTests.cpp
+++ b/lib/Alembic/AbcGeom/Tests/XformTests.cpp
@@ -148,6 +148,9 @@ void xformOut()
     XformSample dsamp;
     dsamp.addOp( scaleop, V3d( 3.0, 6.0, 9.0 ) );
     d.getSchema().set( dsamp );
+    d.getSchema().setFromPrevious();
+    d.getSchema().setFromPrevious();
+    TESTING_ASSERT( d.getSchema().getNumSamples() == 3 );
 
     XformSample esamp;
     M44d identmat;


### PR DESCRIPTION
Per Issue 430 review O*Schema::setFromPrevious and O*Schema::getNumamples to

make sure the former increments the latter appropriately.

Add several unit tests for them.