### PR TITLE
add unicode filename support for Windows

### DIFF
--- a/lib/Alembic/Ogawa/OStream.cpp
+++ b/lib/Alembic/Ogawa/OStream.cpp
@@ -47,8 +47,28 @@ public:
     PrivateData(const std::string & iFileName) :
         stream(NULL), fileName(iFileName), startPos(0), curPos(0), maxPos(0)
     {
+#ifdef _WIN32
+        // to wchar_t
+        // get the size of the UTF8 string
+        int wLength = MultiByteToWideChar(CP_UTF8, 0, fileName.c_str(), -1, NULL, 0);
+
+        // allocate buffer
+        wchar_t* wFileName = (wchar_t*)malloc(wLength * sizeof(wchar_t));
+        if (!wFileName)
+          throw std::runtime_error("Unable to convert to wchar_t file name");
+
+        // convert to UTF8
+        MultiByteToWideChar(CP_UTF8, 0, fileName.c_str(), -1, wFileName, wLength);
+
+        // open stream with UTF8 string
+        std::ofstream * filestream = new std::ofstream(wFileName, std::ios_base::trunc | std::ios_base::binary);
+
+        // free conversion buffer
+        free(wFileName);
+#else
         std::ofstream * filestream = new std::ofstream(fileName.c_str(),
             std::ios_base::trunc | std::ios_base::binary);
+#endif
         if (filestream->is_open())
         {
             stream = filestream;


### PR DESCRIPTION
This will add support for unicode filenames under Windows. We use this code since years in our application "Cinema 4D".