### PR TITLE
fix runtime error

### DIFF
--- a/lib/Alembic/Ogawa/IStreams.cpp
+++ b/lib/Alembic/Ogawa/IStreams.cpp
@@ -697,6 +697,13 @@ public:
                 return;
             }
             bool filefrozen = (header[5] == char(0xff));
+	    if (header[6] < 0)
+	    {
+                frozen = false;
+                valid = false;
+                version = 0;
+                return;
+            }	    
             Alembic::Util::uint16_t fileversion = (header[6] << 8) | header[7];
             Alembic::Util::uint64_t groupPos = *((Alembic::Util::uint64_t*) (&(header[8])));
             Alembic::Util::uint64_t filesize = iReader->size();


### PR DESCRIPTION
this patch fix runtime error

runtime error: left shift of negative value -7
    #0 0x5fdb9103293d in Alembic::Ogawa::v12::IStreams::PrivateData::init(std::shared_ptr<Alembic::Ogawa::v12::(anonymous namespace)::IStreamReader>, unsigned long) /home/ubuntu/a/alembic-p/alembic/lib/Alembic/Ogawa/IStreams.cpp:700:62
    #1 0x5fdb910319ec in Alembic::Ogawa::v12::IStreams::IStreams(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, bool) /home/ubuntu/a/alembic-p/alembic/lib/Alembic/Ogawa/IStreams.cpp:745:12
    #2 0x5fdb9102712a in Alembic::Ogawa::v12::IArchive::IArchive(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, bool) /home/ubuntu/a/alembic-p/alembic/lib/Alembic/Ogawa/IArchive.cpp:45:18
    #3 0x5fdb90e3ab6d in Alembic::AbcCoreOgawa::v12::ArImpl::ArImpl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, bool) /home/ubuntu/a/alembic-p/alembic/lib/Alembic/AbcCoreOgawa/ArImpl.cpp:51:5
    #4 0x5fdb90d405cd in Alembic::AbcCoreOgawa::v12::ReadArchive::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<Alembic::AbcCoreAbstract::v12::ReadArraySampleCache>) const /home/ubuntu/a/alembic-p/alembic/lib/Alembic/AbcCoreOgawa/ReadWrite.cpp:121:17
    #5 0x5fdb90d35a43 in Alembic::Abc::v12::IArchive::IArchive<Alembic::AbcCoreOgawa::v12::ReadArchive>(Alembic::AbcCoreOgawa::v12::ReadArchive, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Alembic::Abc::v12::ErrorHandler::Policy, std::shared_ptr<Alembic::AbcCoreAbstract::v12::ReadArraySampleCache>) /home/ubuntu/a/alembic-p/alembic/lib/Alembic/Abc/IArchive.h:208:17
    #6 0x5fdb90d32e0f in Alembic::AbcCoreFactory::v12::IFactory::getArchive(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Alembic::AbcCoreFactory::v12::IFactory::CoreType&) /home/ubuntu/a/alembic-p/alembic/lib/Alembic/AbcCoreFactory/IFactory.cpp:70:28
    #7 0x5fdb90d33fc4 in Alembic::AbcCoreFactory::v12::IFactory::getArchive(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ubuntu/a/alembic-p/alembic/lib/Alembic/AbcCoreFactory/IFactory.cpp:118:12
    #8 0x5fdb90c81569 in dumpInfo(char const*) /home/ubuntu/a/alembic-p/alembic/../alembic/alembic_dump_info_fuzzer.cc:191:30
    #9 0x5fdb90c81977 in LLVMFuzzerTestOneInput /home/ubuntu/a/alembic-p/alembic/../alembic/alembic_dump_info_fuzzer.cc:201:3
    #10 0x5fdb91059134 in main /home/ubuntu/a/alembic-p/alembic/main.cc:46:3
    #11 0x79110b229d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #12 0x79110b229e3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #13 0x5fdb90bbc934 in _start (/home/ubuntu/a/alembic-p/alembic/out/alembic_dump_info_fuzzer+0x5f7934) (BuildId: 8b703abe806386a