### PR TITLE
Land cmake files in expected location for 64 bit RH-derived systems

### DIFF
--- a/lib/Alembic/CMakeLists.txt
+++ b/lib/Alembic/CMakeLists.txt
@@ -96,7 +96,7 @@ INSTALL(TARGETS Alembic
 
 set(alembic_targets_file "${PROJECT_NAME}Targets.cmake")
 
-SET(ConfigPackageLocation lib/cmake/Alembic CACHE PATH
+SET(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/Alembic CACHE PATH
         "Where to install the Alembic's cmake files")
 
 INCLUDE(CMakePackageConfigHelpers)


### PR DESCRIPTION
On 64 bit RedHat-based distributions, the installation directory is `lib64` rather than `lib`. `${CMAKE_INSTALL_LIBDIR}` gets you the right installation directory for cmake files instead of hard coding to `lib`.