### PR TITLE
Validate the IArchive in several of our CLI tools.

### DIFF
--- a/bin/AbcEcho/AbcBoundsEcho.cpp
+++ b/bin/AbcEcho/AbcBoundsEcho.cpp
@@ -180,6 +180,12 @@ int main( int argc, char *argv[] )
         Alembic::AbcCoreFactory::IFactory factory;
         factory.setPolicy(ErrorHandler::kQuietNoopPolicy);
         IArchive archive = factory.getArchive( argv[1] );
+        if (!archive.valid())
+        {
+            std::cerr << "Invalid archive: " << argv[1] << std::endl;
+            exit( -1 );
+        }
+
         visitObject( archive.getTop(), seconds );
     }
 

--- a/bin/AbcEcho/AbcEcho.cpp
+++ b/bin/AbcEcho/AbcEcho.cpp
@@ -259,8 +259,8 @@ int main( int argc, char *argv[] )
                           << std::endl;
                 std::cout << std::endl;
             }
+            visitObject( archive.getTop(), "" );
         }
-        visitObject( archive.getTop(), "" );
     }
 
     return 0;

--- a/bin/AbcLs/AbcLs.cpp
+++ b/bin/AbcLs/AbcLs.cpp
@@ -740,6 +740,11 @@ int main( int argc, char *argv[] )
         AbcF::IFactory::CoreType coreType;
         archive = factory.getArchive(std::string( fp.str() ), coreType);
 
+        if (!archive)
+        {
+            continue;
+        }
+
         // display file metadata
         if ( opt_meta && seglist.size() == 0 ) {
             std::cout  << "Using "

--- a/bin/AbcTree/AbcTree.cpp
+++ b/bin/AbcTree/AbcTree.cpp
@@ -341,6 +341,10 @@ int main( int argc, char *argv[] )
         factory.setPolicy(Abc::ErrorHandler::kQuietNoopPolicy);
         AbcF::IFactory::CoreType coreType;
         archive = factory.getArchive(std::string( fp.str() ), coreType);
+        if (!archive)
+        {
+            continue;
+        }
 
         // display file metadata 
         if ( opt_meta ) {


### PR DESCRIPTION
Make sure the archive is valid in several of the CLI tools before trying to do stuff with it to avoid a segfault.