### PR TITLE
Fix heap overrun in ReadData wstring branch.

### DIFF
--- a/lib/Alembic/AbcCoreOgawa/ReadUtil.cpp
+++ b/lib/Alembic/AbcCoreOgawa/ReadUtil.cpp
@@ -1404,7 +1404,8 @@ ReadData( void * iIntoLocation,
 
         std::size_t numChars = ( dataSize - 16 ) / 4;
         Util::uint32_t * buf = new Util::uint32_t[ numChars ];
-        iData->read( dataSize - 16, buf, 16, iThreadId );
+        iData->read( numChars * sizeof( Util::uint32_t ), buf, 16,
+            iThreadId );
 
         std::size_t strPos = 0;
 


### PR DESCRIPTION
iData->read is called with (dataSize - 16) bytes but the destination buffer is sized ((dataSize - 16) / 4) * 4 bytes, overrunning by up to 3 bytes when the data block size minus the 16-byte key is not a multiple of four. Clamp the read to numChars * sizeof(uint32_t).